### PR TITLE
Fix kubectl run timeout with service account

### DIFF
--- a/tp5/README.md
+++ b/tp5/README.md
@@ -248,7 +248,7 @@ kubectl auth can-i delete pods --as=system:serviceaccount:default:my-app-sa
 
 # Tester depuis un pod
 kubectl run test-permissions --image=bitnami/kubectl:latest --rm -it \
-  --overrides='{"spec":{"serviceAccountName":"my-app-sa"}}' -- bash
+  --overrides='{"spec":{"serviceAccountName":"my-app-sa"}}' -- sh
 
 # Dans le pod :
 # kubectl get pods    # Should work


### PR DESCRIPTION
…le TP5

- Remplacer 'bash' par 'sh' dans la commande de test des permissions
- L'image bitnami/kubectl:latest utilise sh comme shell par défaut
- Cela résout le problème de timeout lors de l'exécution de la commande interactive

Fixes #issue avec timeout dans l'exercice 3 du TP5