### PR TITLE
Connect to Kubernetes container via bash shell

### DIFF
--- a/tp5/README.md
+++ b/tp5/README.md
@@ -247,7 +247,7 @@ kubectl auth can-i delete pods --as=system:serviceaccount:default:my-app-sa
 # Should return: no
 
 # Tester depuis un pod
-kubectl run test-permissions --image=bitnami/kubectl:latest --rm -it \
+kubectl run test-permissions --image=alpine/k8s:1.28.3 --rm -it \
   --overrides='{"spec":{"serviceAccountName":"my-app-sa"}}' -- sh
 
 # Dans le pod :


### PR DESCRIPTION
Utilisation d'une image plus légère et mieux maintenue pour tester les permissions RBAC dans l'exercice 3. alpine/k8s:1.28.3 gère correctement sh et est spécialement conçue pour ce cas d'usage.