### PR TITLE
Add GitHub Actions alternative for TP6

### DIFF
--- a/tp6/ALTERNATIVE_SANS_GITHUB.md
+++ b/tp6/ALTERNATIVE_SANS_GITHUB.md
@@ -1,0 +1,857 @@
+# Alternative CI/CD sans GitHub - Utilisation de Tekton
+
+## Pour ceux qui ne souhaitent pas créer de compte GitHub
+
+Cette alternative vous permet de mettre en place un pipeline CI/CD complet directement dans votre cluster Kubernetes, **sans avoir besoin de compte GitHub ou autre service externe**.
+
+Nous utiliserons **Tekton**, un framework CI/CD Kubernetes-native, open source et gratuit.
+
+## Pourquoi Tekton ?
+
+- **Kubernetes-native** : S'exécute directement dans votre cluster
+- **Aucun compte externe requis** : Tout est local
+- **Open source et gratuit**
+- **Déclaratif** : Configuration en YAML comme Kubernetes
+- **Réutilisable** : Tasks et pipelines modulaires
+- **Cloud-agnostic** : Fonctionne partout où Kubernetes fonctionne
+
+## Table des matières
+
+1. [Installation de Tekton](#installation-de-tekton)
+2. [Concepts de base](#concepts-de-base)
+3. [Pipeline CI (Tests et Build)](#pipeline-ci-tests-et-build)
+4. [Pipeline CD (Déploiement)](#pipeline-cd-déploiement)
+5. [Déclenchement des pipelines](#déclenchement-des-pipelines)
+6. [Monitoring des pipelines](#monitoring-des-pipelines)
+7. [Comparaison avec GitHub Actions](#comparaison-avec-github-actions)
+
+---
+
+## Installation de Tekton
+
+### 1. Installer Tekton Pipelines
+
+```bash
+# Installer Tekton Pipelines (core)
+kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+
+# Vérifier l'installation
+kubectl get pods -n tekton-pipelines
+
+# Attendre que tous les pods soient prêts
+kubectl wait --for=condition=ready pod --all -n tekton-pipelines --timeout=300s
+```
+
+### 2. Installer Tekton Triggers (optionnel, pour automation)
+
+```bash
+# Installer Tekton Triggers
+kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
+kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml
+
+# Vérifier
+kubectl get pods -n tekton-pipelines
+```
+
+### 3. Installer Tekton Dashboard (interface graphique)
+
+```bash
+# Installer le Dashboard
+kubectl apply -f https://storage.googleapis.com/tekton-releases/dashboard/latest/release.yaml
+
+# Exposer le Dashboard
+kubectl port-forward -n tekton-pipelines service/tekton-dashboard 9097:9097 &
+
+# Accéder au Dashboard
+echo "Dashboard disponible sur : http://localhost:9097"
+```
+
+### 4. Installer Tekton CLI (optionnel mais recommandé)
+
+```bash
+# Linux
+curl -LO https://github.com/tektoncd/cli/releases/download/v0.33.0/tkn_0.33.0_Linux_x86_64.tar.gz
+sudo tar xvzf tkn_0.33.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
+
+# Vérifier
+tkn version
+
+# macOS avec Homebrew
+# brew install tektoncd-cli
+```
+
+---
+
+## Concepts de base
+
+### Hiérarchie Tekton
+
+```
+Task          → Étape atomique (équivalent à un job GitHub Actions)
+Pipeline      → Séquence de Tasks
+PipelineRun   → Instance d'exécution d'un Pipeline
+TaskRun       → Instance d'exécution d'une Task
+```
+
+### Workspaces
+
+Les **Workspaces** permettent de partager des données entre Tasks (code source, artifacts, cache).
+
+---
+
+## Pipeline CI (Tests et Build)
+
+### Étape 1 : Créer les Tasks
+
+Créer `tekton/tasks/git-clone-task.yaml` :
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+  namespace: default
+spec:
+  description: Clone un repository Git
+  workspaces:
+    - name: output
+      description: Le workspace où cloner le code
+  params:
+    - name: url
+      type: string
+      description: URL du repository Git
+    - name: revision
+      type: string
+      default: main
+      description: Branch, tag ou SHA à cloner
+  steps:
+    - name: clone
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.40.2
+      script: |
+        #!/bin/sh
+        set -e
+        git clone $(params.url) $(workspaces.output.path)
+        cd $(workspaces.output.path)
+        git checkout $(params.revision)
+        echo "Code cloné avec succès!"
+```
+
+Créer `tekton/tasks/npm-test-task.yaml` :
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: npm-test
+  namespace: default
+spec:
+  description: Exécute les tests npm
+  workspaces:
+    - name: source
+  params:
+    - name: node-version
+      type: string
+      default: "18"
+  steps:
+    - name: install-dependencies
+      image: node:$(params.node-version)-alpine
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Installation des dépendances..."
+        npm ci
+
+    - name: run-tests
+      image: node:$(params.node-version)-alpine
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Exécution des tests..."
+        npm test
+
+    - name: lint
+      image: node:$(params.node-version)-alpine
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Linting du code..."
+        npm run lint || echo "Pas de lint configuré"
+```
+
+Créer `tekton/tasks/docker-build-task.yaml` :
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: docker-build
+  namespace: default
+spec:
+  description: Build et push d'une image Docker
+  workspaces:
+    - name: source
+  params:
+    - name: image
+      type: string
+      description: Nom complet de l'image (registry/name:tag)
+    - name: dockerfile
+      type: string
+      default: Dockerfile
+      description: Chemin vers le Dockerfile
+  steps:
+    - name: build-and-push
+      image: gcr.io/kaniko-project/executor:latest
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: DOCKER_CONFIG
+          value: /tekton/home/.docker
+      command:
+        - /kaniko/executor
+      args:
+        - --dockerfile=$(params.dockerfile)
+        - --context=$(workspaces.source.path)
+        - --destination=$(params.image)
+        - --skip-tls-verify
+        - --cache=true
+      volumeMounts:
+        - name: docker-config
+          mountPath: /tekton/home/.docker
+  volumes:
+    - name: docker-config
+      emptyDir: {}
+```
+
+Créer `tekton/tasks/trivy-scan-task.yaml` :
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: trivy-scan
+  namespace: default
+spec:
+  description: Scan de sécurité avec Trivy
+  params:
+    - name: image
+      type: string
+      description: Image à scanner
+  steps:
+    - name: scan
+      image: aquasec/trivy:latest
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Scan de sécurité de l'image..."
+        trivy image --severity HIGH,CRITICAL $(params.image) || true
+        echo "Scan terminé!"
+```
+
+### Étape 2 : Créer le Pipeline CI
+
+Créer `tekton/pipelines/ci-pipeline.yaml` :
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: ci-pipeline
+  namespace: default
+spec:
+  description: Pipeline CI complet - Tests et Build
+  params:
+    - name: git-url
+      type: string
+      description: URL du repository Git
+    - name: git-revision
+      type: string
+      default: main
+    - name: image-name
+      type: string
+      description: Nom de l'image Docker (sans tag)
+    - name: image-tag
+      type: string
+      default: latest
+
+  workspaces:
+    - name: shared-workspace
+      description: Workspace partagé pour le code source
+
+  tasks:
+    # Task 1: Cloner le repository
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.git-revision)
+
+    # Task 2: Tests npm (dépend de fetch-repository)
+    - name: run-tests
+      taskRef:
+        name: npm-test
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: node-version
+          value: "18"
+
+    # Task 3: Build Docker (dépend de run-tests)
+    - name: build-image
+      taskRef:
+        name: docker-build
+      runAfter:
+        - run-tests
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: image
+          value: "$(params.image-name):$(params.image-tag)"
+
+    # Task 4: Scan de sécurité (dépend de build-image)
+    - name: security-scan
+      taskRef:
+        name: trivy-scan
+      runAfter:
+        - build-image
+      params:
+        - name: image
+          value: "$(params.image-name):$(params.image-tag)"
+```
+
+### Étape 3 : Appliquer les ressources
+
+```bash
+# Créer les tasks
+kubectl apply -f tekton/tasks/git-clone-task.yaml
+kubectl apply -f tekton/tasks/npm-test-task.yaml
+kubectl apply -f tekton/tasks/docker-build-task.yaml
+kubectl apply -f tekton/tasks/trivy-scan-task.yaml
+
+# Créer le pipeline
+kubectl apply -f tekton/pipelines/ci-pipeline.yaml
+
+# Vérifier
+tkn task list
+tkn pipeline list
+```
+
+---
+
+## Pipeline CD (Déploiement)
+
+### Étape 1 : Créer les Tasks de déploiement
+
+Créer `tekton/tasks/helm-deploy-task.yaml` :
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: helm-deploy
+  namespace: default
+spec:
+  description: Déploiement avec Helm
+  params:
+    - name: release-name
+      type: string
+      description: Nom de la release Helm
+    - name: chart-path
+      type: string
+      description: Chemin vers le chart Helm
+    - name: namespace
+      type: string
+      default: default
+    - name: image-repository
+      type: string
+    - name: image-tag
+      type: string
+  workspaces:
+    - name: source
+  steps:
+    - name: deploy
+      image: alpine/helm:latest
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Déploiement avec Helm..."
+
+        helm upgrade --install $(params.release-name) \
+          $(workspaces.source.path)/$(params.chart-path) \
+          --namespace $(params.namespace) \
+          --create-namespace \
+          --set image.repository=$(params.image-repository) \
+          --set image.tag=$(params.image-tag) \
+          --wait \
+          --timeout 5m
+
+        echo "Déploiement terminé!"
+```
+
+Créer `tekton/tasks/kubectl-verify-task.yaml` :
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kubectl-verify
+  namespace: default
+spec:
+  description: Vérification du déploiement
+  params:
+    - name: deployment-name
+      type: string
+    - name: namespace
+      type: string
+      default: default
+  steps:
+    - name: verify-deployment
+      image: bitnami/kubectl:latest
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Vérification du rollout..."
+        kubectl rollout status deployment/$(params.deployment-name) -n $(params.namespace)
+
+        echo "Liste des pods:"
+        kubectl get pods -n $(params.namespace)
+
+    - name: smoke-test
+      image: curlimages/curl:latest
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Exécution des smoke tests..."
+        # Ajouter vos tests ici
+        echo "Tests terminés!"
+```
+
+### Étape 2 : Créer le Pipeline CD
+
+Créer `tekton/pipelines/cd-pipeline.yaml` :
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cd-pipeline
+  namespace: default
+spec:
+  description: Pipeline CD - Déploiement sur Kubernetes
+  params:
+    - name: git-url
+      type: string
+    - name: git-revision
+      type: string
+      default: main
+    - name: release-name
+      type: string
+      default: my-app
+    - name: chart-path
+      type: string
+      default: helm/my-app
+    - name: namespace
+      type: string
+      default: production
+    - name: image-repository
+      type: string
+    - name: image-tag
+      type: string
+    - name: deployment-name
+      type: string
+      default: my-app
+
+  workspaces:
+    - name: shared-workspace
+
+  tasks:
+    # Task 1: Cloner le repository (pour les charts Helm)
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.git-revision)
+
+    # Task 2: Déployer avec Helm
+    - name: deploy-with-helm
+      taskRef:
+        name: helm-deploy
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: release-name
+          value: $(params.release-name)
+        - name: chart-path
+          value: $(params.chart-path)
+        - name: namespace
+          value: $(params.namespace)
+        - name: image-repository
+          value: $(params.image-repository)
+        - name: image-tag
+          value: $(params.image-tag)
+
+    # Task 3: Vérifier le déploiement
+    - name: verify-deployment
+      taskRef:
+        name: kubectl-verify
+      runAfter:
+        - deploy-with-helm
+      params:
+        - name: deployment-name
+          value: $(params.deployment-name)
+        - name: namespace
+          value: $(params.namespace)
+```
+
+### Étape 3 : Appliquer les ressources
+
+```bash
+# Créer les tasks
+kubectl apply -f tekton/tasks/helm-deploy-task.yaml
+kubectl apply -f tekton/tasks/kubectl-verify-task.yaml
+
+# Créer le pipeline
+kubectl apply -f tekton/pipelines/cd-pipeline.yaml
+
+# Vérifier
+tkn pipeline list
+```
+
+---
+
+## Déclenchement des pipelines
+
+### Option 1 : Déclenchement manuel avec PipelineRun
+
+Créer `tekton/runs/ci-pipelinerun.yaml` :
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: ci-run-$(date +%Y%m%d-%H%M%S)
+  namespace: default
+spec:
+  pipelineRef:
+    name: ci-pipeline
+  params:
+    - name: git-url
+      value: "https://github.com/votre-username/votre-repo.git"
+    - name: git-revision
+      value: "main"
+    - name: image-name
+      value: "localhost:5000/my-app"  # Registry local
+    - name: image-tag
+      value: "latest"
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+```
+
+Exécuter :
+
+```bash
+# Exécuter le pipeline CI
+kubectl create -f tekton/runs/ci-pipelinerun.yaml
+
+# Ou avec tkn CLI
+tkn pipeline start ci-pipeline \
+  --param git-url=https://github.com/votre-username/votre-repo.git \
+  --param git-revision=main \
+  --param image-name=localhost:5000/my-app \
+  --param image-tag=v1.0.0 \
+  --workspace name=shared-workspace,volumeClaimTemplateFile=workspace-template.yaml \
+  --showlog
+```
+
+### Option 2 : Déclenchement automatique avec Git Hooks locaux
+
+Créer `.git/hooks/pre-push` :
+
+```bash
+#!/bin/bash
+
+echo "Déclenchement du pipeline CI Tekton..."
+
+# Créer un PipelineRun
+kubectl create -f - <<EOF
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: ci-run-
+  namespace: default
+spec:
+  pipelineRef:
+    name: ci-pipeline
+  params:
+    - name: git-url
+      value: "file:///path/to/local/repo"
+    - name: git-revision
+      value: "$(git rev-parse HEAD)"
+    - name: image-name
+      value: "localhost:5000/my-app"
+    - name: image-tag
+      value: "$(git rev-parse --short HEAD)"
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+EOF
+
+echo "Pipeline déclenché!"
+```
+
+```bash
+# Rendre le hook exécutable
+chmod +x .git/hooks/pre-push
+```
+
+### Option 3 : Registry Docker local (pour éviter les registries externes)
+
+```bash
+# Démarrer un registry Docker local
+kubectl create deployment registry --image=registry:2
+kubectl expose deployment registry --port=5000 --type=NodePort
+
+# Obtenir le port
+kubectl get svc registry
+
+# Utiliser localhost:5000 comme registry dans vos pipelines
+```
+
+---
+
+## Monitoring des pipelines
+
+### Via Tekton Dashboard
+
+```bash
+# Exposer le Dashboard si pas déjà fait
+kubectl port-forward -n tekton-pipelines service/tekton-dashboard 9097:9097
+
+# Ouvrir dans le navigateur
+open http://localhost:9097
+```
+
+### Via CLI
+
+```bash
+# Lister tous les PipelineRuns
+tkn pipelinerun list
+
+# Voir les logs d'un PipelineRun
+tkn pipelinerun logs ci-run-20240101-123456 -f
+
+# Voir les détails
+tkn pipelinerun describe ci-run-20240101-123456
+
+# Lister les TaskRuns
+tkn taskrun list
+
+# Supprimer les anciens runs
+tkn pipelinerun delete --keep 5
+```
+
+### Via kubectl
+
+```bash
+# Voir tous les PipelineRuns
+kubectl get pipelinerun
+
+# Voir les détails
+kubectl describe pipelinerun ci-run-20240101-123456
+
+# Voir les logs d'un TaskRun
+kubectl logs -l tekton.dev/pipelineRun=ci-run-20240101-123456
+```
+
+---
+
+## Comparaison avec GitHub Actions
+
+| Fonctionnalité | GitHub Actions | Tekton |
+|---------------|----------------|--------|
+| **Hébergement** | Cloud GitHub | Votre cluster K8s |
+| **Compte requis** | Oui (GitHub) | Non |
+| **Coût** | Gratuit (limité) puis payant | Gratuit (coût infra) |
+| **Déclencheurs** | Git events automatiques | Manuel ou webhooks |
+| **Secrets** | GitHub Secrets | Kubernetes Secrets |
+| **Registry** | ghcr.io | Local ou externe |
+| **Interface Web** | Intégré GitHub | Tekton Dashboard |
+| **Configuration** | .github/workflows/*.yml | Tasks + Pipelines YAML |
+| **Réutilisabilité** | Actions Marketplace | Task catalog |
+| **Scaling** | Automatique | Dépend du cluster |
+
+---
+
+## Avantages de l'approche Tekton
+
+### 1. Aucune dépendance externe
+- Pas de compte GitHub, GitLab, ou autre
+- Tout tourne dans votre cluster
+- Contrôle total sur l'infrastructure
+
+### 2. GitOps-friendly
+- Compatible avec ArgoCD
+- Configuration déclarative
+- Versionnable dans Git
+
+### 3. Évolutif et flexible
+- Peut évoluer vers des setups complexes
+- Intégrable avec d'autres outils K8s
+- Pas de vendor lock-in
+
+### 4. Apprentissage Kubernetes
+- Renforce la compréhension de K8s
+- Utilise les concepts natifs (Pods, Volumes, etc.)
+- Transférable à n'importe quel cluster
+
+---
+
+## Script d'installation complète
+
+Créer `tekton/install-tekton.sh` :
+
+```bash
+#!/bin/bash
+
+set -e
+
+echo "=== Installation de Tekton ===="
+
+# 1. Installer Tekton Pipelines
+echo "Installation de Tekton Pipelines..."
+kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+
+echo "Attente que Tekton soit prêt..."
+kubectl wait --for=condition=ready pod --all -n tekton-pipelines --timeout=300s
+
+# 2. Installer Tekton Triggers
+echo "Installation de Tekton Triggers..."
+kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
+kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml
+
+# 3. Installer Tekton Dashboard
+echo "Installation du Tekton Dashboard..."
+kubectl apply -f https://storage.googleapis.com/tekton-releases/dashboard/latest/release.yaml
+
+echo "Attente que le Dashboard soit prêt..."
+kubectl wait --for=condition=ready pod -l app=tekton-dashboard -n tekton-pipelines --timeout=300s
+
+# 4. Installer un registry local
+echo "Installation d'un registry Docker local..."
+kubectl create deployment registry --image=registry:2 --dry-run=client -o yaml | kubectl apply -f -
+kubectl expose deployment registry --port=5000 --type=NodePort --dry-run=client -o yaml | kubectl apply -f -
+
+# 5. Appliquer les Tasks et Pipelines
+echo "Application des Tasks et Pipelines..."
+kubectl apply -f tekton/tasks/
+kubectl apply -f tekton/pipelines/
+
+echo ""
+echo "=== Installation terminée! ==="
+echo ""
+echo "Pour accéder au Dashboard Tekton:"
+echo "  kubectl port-forward -n tekton-pipelines service/tekton-dashboard 9097:9097"
+echo "  Puis ouvrir: http://localhost:9097"
+echo ""
+echo "Pour exécuter un pipeline:"
+echo "  tkn pipeline start ci-pipeline --showlog"
+echo ""
+```
+
+```bash
+# Rendre le script exécutable
+chmod +x tekton/install-tekton.sh
+
+# Exécuter
+./tekton/install-tekton.sh
+```
+
+---
+
+## Exercices pratiques
+
+### Exercice 1 : Pipeline CI basique
+
+1. Installer Tekton
+2. Créer les tasks nécessaires
+3. Créer un pipeline CI
+4. L'exécuter manuellement
+5. Observer les résultats dans le Dashboard
+
+### Exercice 2 : Pipeline CD
+
+1. Créer les tasks de déploiement
+2. Créer un pipeline CD
+3. L'exécuter pour déployer sur Kubernetes
+4. Vérifier le déploiement
+
+### Exercice 3 : Automation complète
+
+1. Configurer un registry local
+2. Créer un git hook pour déclencher le pipeline
+3. Faire un commit et observer le déclenchement automatique
+
+---
+
+## Ressources complémentaires
+
+### Documentation officielle
+- [Tekton Documentation](https://tekton.dev/docs/)
+- [Tekton Catalog](https://hub.tekton.dev/) - Tasks réutilisables
+- [Tekton GitHub](https://github.com/tektoncd)
+
+### Tutoriels
+- [Getting Started with Tekton](https://tekton.dev/docs/getting-started/)
+- [Tekton Tutorial](https://github.com/tektoncd/pipeline/blob/main/docs/tutorial.md)
+
+### Alternatives CI/CD Kubernetes-native
+- **Jenkins X** : CI/CD avec GitOps
+- **Argo Workflows** : Workflow engine
+- **Drone CI** : Peut être self-hosted
+
+---
+
+## Conclusion
+
+Avec Tekton, vous disposez d'une solution CI/CD complète, Kubernetes-native, **sans avoir besoin de créer un compte sur GitHub ou tout autre service externe**.
+
+Cette approche est idéale pour :
+- L'apprentissage de Kubernetes et du CI/CD
+- Les environnements on-premise
+- Les projets nécessitant un contrôle total
+- Les budgets limités (pas de coûts de service externe)
+
+**Vous êtes maintenant autonome pour créer vos pipelines CI/CD directement dans Kubernetes !**

--- a/tp6/README.md
+++ b/tp6/README.md
@@ -18,8 +18,26 @@
 - Avoir complété les TP1 à TP5
 - Un cluster minikube fonctionnel
 - Connaissance des concepts de base de Kubernetes
-- Compte GitHub (pour le CI/CD)
+- Compte GitHub (pour le CI/CD) **OU** voir l'alternative Tekton ci-dessous
 - Compréhension de Docker et des conteneurs
+
+> **Note importante** : Si vous ne souhaitez pas créer de compte GitHub, consultez le fichier [ALTERNATIVE_SANS_GITHUB.md](./ALTERNATIVE_SANS_GITHUB.md) qui explique comment mettre en place un pipeline CI/CD complet avec **Tekton**, directement dans votre cluster Kubernetes, sans aucun service externe.
+
+## Choix de votre solution CI/CD
+
+Ce TP propose **deux approches** pour le CI/CD :
+
+### Option 1 : GitHub Actions (recommandé pour la découverte)
+- **Avantages** : Interface intuitive, intégration GitHub, gratuit pour usage personnel
+- **Inconvénients** : Nécessite un compte GitHub
+- **Documentation** : Voir Partie 3 de ce README
+
+### Option 2 : Tekton (recommandé pour l'apprentissage Kubernetes)
+- **Avantages** : Kubernetes-native, aucun compte externe, contrôle total
+- **Inconvénients** : Plus technique, nécessite plus de configuration
+- **Documentation** : Voir [ALTERNATIVE_SANS_GITHUB.md](./ALTERNATIVE_SANS_GITHUB.md)
+
+**Les deux approches couvrent les mêmes fonctionnalités** : tests automatiques, build Docker, scan de sécurité, et déploiement sur Kubernetes.
 
 ## Partie 1 : Introduction à Helm
 
@@ -2092,12 +2110,14 @@ Dans ce TP, vous avez appris à :
 
 - **Helm** : Gérer des applications avec des Charts
 - **Ingress** : Exposer des services avec routing avancé
-- **CI/CD** : Automatiser les déploiements avec GitHub Actions
+- **CI/CD** : Automatiser les déploiements avec GitHub Actions ou Tekton
 - **Stratégies de déploiement** : Rolling, Blue-Green, Canary
 - **GitOps** : Déployer avec ArgoCD
 - **Production** : HPA, PDB, health checks, monitoring
 - **Secrets** : Sealed Secrets pour Git
 - **Kustomize** : Gérer plusieurs environnements
+
+> **Alternative sans compte GitHub** : Voir [ALTERNATIVE_SANS_GITHUB.md](./ALTERNATIVE_SANS_GITHUB.md) pour utiliser Tekton au lieu de GitHub Actions.
 
 ### Concepts clés
 
@@ -2120,6 +2140,7 @@ Dans ce TP, vous avez appris à :
 - [Ingress NGINX](https://kubernetes.github.io/ingress-nginx/)
 - [ArgoCD](https://argo-cd.readthedocs.io/)
 - [GitHub Actions](https://docs.github.com/en/actions)
+- [Tekton](https://tekton.dev/docs/) - Alternative CI/CD sans compte GitHub
 - [Kustomize](https://kustomize.io/)
 - [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets)
 

--- a/tp6/tekton/README.md
+++ b/tp6/tekton/README.md
@@ -1,0 +1,165 @@
+# Tekton CI/CD - Quick Start
+
+Ce dossier contient tous les fichiers nécessaires pour mettre en place un pipeline CI/CD avec Tekton, sans avoir besoin de compte GitHub.
+
+## Structure
+
+```
+tekton/
+├── tasks/              # Tasks individuelles (git clone, tests, build, etc.)
+├── pipelines/          # Pipelines complets (CI et CD)
+├── runs/               # Exemples de PipelineRun pour exécuter les pipelines
+├── install-tekton.sh   # Script d'installation automatique
+└── README.md           # Ce fichier
+```
+
+## Installation rapide
+
+```bash
+# Exécuter le script d'installation
+./install-tekton.sh
+```
+
+Ce script va :
+1. Installer Tekton Pipelines
+2. Installer Tekton Triggers
+3. Installer le Tekton Dashboard
+4. Créer un registry Docker local
+5. Appliquer toutes les Tasks et Pipelines
+
+## Accéder au Dashboard
+
+```bash
+# Exposer le Dashboard
+kubectl port-forward -n tekton-pipelines service/tekton-dashboard 9097:9097
+
+# Ouvrir dans le navigateur
+open http://localhost:9097
+```
+
+## Exécuter le pipeline CI
+
+### Option 1 : Via kubectl
+
+```bash
+# Modifier le fichier runs/ci-pipelinerun-example.yaml avec vos paramètres
+# Puis exécuter :
+kubectl create -f runs/ci-pipelinerun-example.yaml
+
+# Suivre les logs
+kubectl logs -f $(kubectl get pods -l tekton.dev/pipelineRun --sort-by=.metadata.creationTimestamp -o name | tail -1)
+```
+
+### Option 2 : Via tkn CLI (si installé)
+
+```bash
+tkn pipeline start ci-pipeline \
+  --param git-url=https://github.com/votre-username/votre-repo.git \
+  --param git-revision=main \
+  --param image-name=localhost:5000/my-app \
+  --param image-tag=v1.0.0 \
+  --workspace name=shared-workspace,volumeClaimTemplateFile=workspace-template.yaml \
+  --showlog
+```
+
+## Exécuter le pipeline CD
+
+```bash
+# Modifier runs/cd-pipelinerun-example.yaml avec vos paramètres
+kubectl create -f runs/cd-pipelinerun-example.yaml
+
+# Ou via tkn
+tkn pipeline start cd-pipeline \
+  --param git-url=https://github.com/votre-username/votre-repo.git \
+  --param git-revision=main \
+  --param release-name=my-app \
+  --param chart-path=helm/my-app \
+  --param namespace=production \
+  --param image-repository=localhost:5000/my-app \
+  --param image-tag=v1.0.0 \
+  --param deployment-name=my-app \
+  --showlog
+```
+
+## Lister les ressources
+
+```bash
+# Lister les Tasks
+kubectl get tasks
+
+# Lister les Pipelines
+kubectl get pipelines
+
+# Lister les PipelineRuns
+kubectl get pipelineruns
+
+# Voir les détails d'un PipelineRun
+tkn pipelinerun describe <pipelinerun-name>
+
+# Voir les logs
+tkn pipelinerun logs <pipelinerun-name> -f
+```
+
+## Nettoyer les anciens runs
+
+```bash
+# Supprimer les PipelineRuns terminés
+kubectl delete pipelinerun --all
+
+# Ou garder les 5 derniers
+tkn pipelinerun delete --keep 5
+```
+
+## Registry Docker local
+
+Un registry Docker local est installé automatiquement pour stocker vos images sans avoir besoin d'un compte Docker Hub ou GitHub Container Registry.
+
+```bash
+# Obtenir l'URL du registry
+kubectl get svc registry
+
+# Utiliser localhost:5000 dans vos paramètres de pipeline
+# Exemple : image-name=localhost:5000/my-app
+```
+
+## Troubleshooting
+
+### Le pipeline échoue au clone Git
+
+```bash
+# Vérifier que l'URL Git est accessible
+git clone <votre-url>
+
+# Si repository privé, créer un Secret avec les credentials
+kubectl create secret generic git-credentials \
+  --from-literal=username=<username> \
+  --from-literal=password=<token>
+```
+
+### Le build Docker échoue
+
+```bash
+# Vérifier que le Dockerfile existe
+# Vérifier les logs du pod kaniko
+kubectl logs -l tekton.dev/task=docker-build
+```
+
+### Le déploiement Helm échoue
+
+```bash
+# Vérifier que le chart Helm est valide
+helm lint ./helm/my-app
+
+# Vérifier les logs
+kubectl logs -l tekton.dev/task=helm-deploy
+```
+
+## Documentation complète
+
+Pour une documentation complète, voir [../ALTERNATIVE_SANS_GITHUB.md](../ALTERNATIVE_SANS_GITHUB.md)
+
+## Ressources
+
+- [Documentation Tekton](https://tekton.dev/docs/)
+- [Tekton Catalog](https://hub.tekton.dev/) - Tasks réutilisables
+- [Tekton CLI](https://github.com/tektoncd/cli)

--- a/tp6/tekton/install-tekton.sh
+++ b/tp6/tekton/install-tekton.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -e
+
+echo "========================================="
+echo "   Installation de Tekton CI/CD"
+echo "========================================="
+echo ""
+
+# 1. Installer Tekton Pipelines
+echo "1. Installation de Tekton Pipelines..."
+kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+
+echo "   Attente que Tekton Pipelines soit prêt..."
+kubectl wait --for=condition=ready pod --all -n tekton-pipelines --timeout=300s
+
+echo "   ✓ Tekton Pipelines installé"
+echo ""
+
+# 2. Installer Tekton Triggers
+echo "2. Installation de Tekton Triggers..."
+kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
+kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml
+
+echo "   ✓ Tekton Triggers installé"
+echo ""
+
+# 3. Installer Tekton Dashboard
+echo "3. Installation du Tekton Dashboard..."
+kubectl apply -f https://storage.googleapis.com/tekton-releases/dashboard/latest/release.yaml
+
+echo "   Attente que le Dashboard soit prêt..."
+sleep 10
+kubectl wait --for=condition=ready pod -l app=tekton-dashboard -n tekton-pipelines --timeout=300s
+
+echo "   ✓ Tekton Dashboard installé"
+echo ""
+
+# 4. Installer un registry Docker local
+echo "4. Installation d'un registry Docker local..."
+kubectl get deployment registry 2>/dev/null || kubectl create deployment registry --image=registry:2
+kubectl get service registry 2>/dev/null || kubectl expose deployment registry --port=5000 --type=NodePort
+
+echo "   ✓ Registry Docker local installé"
+echo ""
+
+# 5. Appliquer les Tasks et Pipelines
+echo "5. Installation des Tasks et Pipelines..."
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ -d "$SCRIPT_DIR/tasks" ]; then
+    kubectl apply -f "$SCRIPT_DIR/tasks/"
+    echo "   ✓ Tasks installées"
+else
+    echo "   ⚠ Dossier tasks/ non trouvé"
+fi
+
+if [ -d "$SCRIPT_DIR/pipelines" ]; then
+    kubectl apply -f "$SCRIPT_DIR/pipelines/"
+    echo "   ✓ Pipelines installés"
+else
+    echo "   ⚠ Dossier pipelines/ non trouvé"
+fi
+
+echo ""
+echo "========================================="
+echo "   Installation terminée avec succès!"
+echo "========================================="
+echo ""
+echo "Pour accéder au Dashboard Tekton:"
+echo "  kubectl port-forward -n tekton-pipelines service/tekton-dashboard 9097:9097"
+echo "  Puis ouvrir: http://localhost:9097"
+echo ""
+echo "Pour lister les Tasks et Pipelines:"
+echo "  kubectl get tasks"
+echo "  kubectl get pipelines"
+echo ""
+echo "Pour exécuter le pipeline CI:"
+echo "  kubectl create -f tekton/runs/ci-pipelinerun-example.yaml"
+echo ""
+echo "Ou avec tkn CLI (si installé):"
+echo "  tkn pipeline start ci-pipeline --showlog"
+echo ""
+echo "Pour plus d'informations, voir:"
+echo "  cat ALTERNATIVE_SANS_GITHUB.md"
+echo ""

--- a/tp6/tekton/pipelines/cd-pipeline.yaml
+++ b/tp6/tekton/pipelines/cd-pipeline.yaml
@@ -1,0 +1,79 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cd-pipeline
+  namespace: default
+spec:
+  description: Pipeline CD - Déploiement sur Kubernetes
+  params:
+    - name: git-url
+      type: string
+    - name: git-revision
+      type: string
+      default: main
+    - name: release-name
+      type: string
+      default: my-app
+    - name: chart-path
+      type: string
+      default: helm/my-app
+    - name: namespace
+      type: string
+      default: production
+    - name: image-repository
+      type: string
+    - name: image-tag
+      type: string
+    - name: deployment-name
+      type: string
+      default: my-app
+
+  workspaces:
+    - name: shared-workspace
+
+  tasks:
+    # Task 1: Cloner le repository (pour les charts Helm)
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.git-revision)
+
+    # Task 2: Déployer avec Helm
+    - name: deploy-with-helm
+      taskRef:
+        name: helm-deploy
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: release-name
+          value: $(params.release-name)
+        - name: chart-path
+          value: $(params.chart-path)
+        - name: namespace
+          value: $(params.namespace)
+        - name: image-repository
+          value: $(params.image-repository)
+        - name: image-tag
+          value: $(params.image-tag)
+
+    # Task 3: Vérifier le déploiement
+    - name: verify-deployment
+      taskRef:
+        name: kubectl-verify
+      runAfter:
+        - deploy-with-helm
+      params:
+        - name: deployment-name
+          value: $(params.deployment-name)
+        - name: namespace
+          value: $(params.namespace)

--- a/tp6/tekton/pipelines/ci-pipeline.yaml
+++ b/tp6/tekton/pipelines/ci-pipeline.yaml
@@ -1,0 +1,74 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: ci-pipeline
+  namespace: default
+spec:
+  description: Pipeline CI complet - Tests et Build
+  params:
+    - name: git-url
+      type: string
+      description: URL du repository Git
+    - name: git-revision
+      type: string
+      default: main
+    - name: image-name
+      type: string
+      description: Nom de l'image Docker (sans tag)
+    - name: image-tag
+      type: string
+      default: latest
+
+  workspaces:
+    - name: shared-workspace
+      description: Workspace partagé pour le code source
+
+  tasks:
+    # Task 1: Cloner le repository
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.git-revision)
+
+    # Task 2: Tests npm (dépend de fetch-repository)
+    - name: run-tests
+      taskRef:
+        name: npm-test
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: node-version
+          value: "18"
+
+    # Task 3: Build Docker (dépend de run-tests)
+    - name: build-image
+      taskRef:
+        name: docker-build
+      runAfter:
+        - run-tests
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: image
+          value: "$(params.image-name):$(params.image-tag)"
+
+    # Task 4: Scan de sécurité (dépend de build-image)
+    - name: security-scan
+      taskRef:
+        name: trivy-scan
+      runAfter:
+        - build-image
+      params:
+        - name: image
+          value: "$(params.image-name):$(params.image-tag)"

--- a/tp6/tekton/runs/cd-pipelinerun-example.yaml
+++ b/tp6/tekton/runs/cd-pipelinerun-example.yaml
@@ -1,0 +1,34 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: cd-run-
+  namespace: default
+spec:
+  pipelineRef:
+    name: cd-pipeline
+  params:
+    - name: git-url
+      value: "https://github.com/votre-username/votre-repo.git"
+    - name: git-revision
+      value: "main"
+    - name: release-name
+      value: "my-app"
+    - name: chart-path
+      value: "helm/my-app"
+    - name: namespace
+      value: "production"
+    - name: image-repository
+      value: "localhost:5000/my-app"
+    - name: image-tag
+      value: "v1.0.0"
+    - name: deployment-name
+      value: "my-app"
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/tp6/tekton/runs/ci-pipelinerun-example.yaml
+++ b/tp6/tekton/runs/ci-pipelinerun-example.yaml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: ci-run-
+  namespace: default
+spec:
+  pipelineRef:
+    name: ci-pipeline
+  params:
+    - name: git-url
+      value: "https://github.com/votre-username/votre-repo.git"
+    - name: git-revision
+      value: "main"
+    - name: image-name
+      value: "localhost:5000/my-app"  # Registry local
+    - name: image-tag
+      value: "latest"
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/tp6/tekton/tasks/docker-build-task.yaml
+++ b/tp6/tekton/tasks/docker-build-task.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: docker-build
+  namespace: default
+spec:
+  description: Build et push d'une image Docker
+  workspaces:
+    - name: source
+  params:
+    - name: image
+      type: string
+      description: Nom complet de l'image (registry/name:tag)
+    - name: dockerfile
+      type: string
+      default: Dockerfile
+      description: Chemin vers le Dockerfile
+  steps:
+    - name: build-and-push
+      image: gcr.io/kaniko-project/executor:latest
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: DOCKER_CONFIG
+          value: /tekton/home/.docker
+      command:
+        - /kaniko/executor
+      args:
+        - --dockerfile=$(params.dockerfile)
+        - --context=$(workspaces.source.path)
+        - --destination=$(params.image)
+        - --skip-tls-verify
+        - --cache=true
+      volumeMounts:
+        - name: docker-config
+          mountPath: /tekton/home/.docker
+  volumes:
+    - name: docker-config
+      emptyDir: {}

--- a/tp6/tekton/tasks/git-clone-task.yaml
+++ b/tp6/tekton/tasks/git-clone-task.yaml
@@ -1,0 +1,28 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+  namespace: default
+spec:
+  description: Clone un repository Git
+  workspaces:
+    - name: output
+      description: Le workspace où cloner le code
+  params:
+    - name: url
+      type: string
+      description: URL du repository Git
+    - name: revision
+      type: string
+      default: main
+      description: Branch, tag ou SHA à cloner
+  steps:
+    - name: clone
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.40.2
+      script: |
+        #!/bin/sh
+        set -e
+        git clone $(params.url) $(workspaces.output.path)
+        cd $(workspaces.output.path)
+        git checkout $(params.revision)
+        echo "Code cloné avec succès!"

--- a/tp6/tekton/tasks/helm-deploy-task.yaml
+++ b/tp6/tekton/tasks/helm-deploy-task.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: helm-deploy
+  namespace: default
+spec:
+  description: Déploiement avec Helm
+  params:
+    - name: release-name
+      type: string
+      description: Nom de la release Helm
+    - name: chart-path
+      type: string
+      description: Chemin vers le chart Helm
+    - name: namespace
+      type: string
+      default: default
+    - name: image-repository
+      type: string
+    - name: image-tag
+      type: string
+  workspaces:
+    - name: source
+  steps:
+    - name: deploy
+      image: alpine/helm:latest
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Déploiement avec Helm..."
+
+        helm upgrade --install $(params.release-name) \
+          $(workspaces.source.path)/$(params.chart-path) \
+          --namespace $(params.namespace) \
+          --create-namespace \
+          --set image.repository=$(params.image-repository) \
+          --set image.tag=$(params.image-tag) \
+          --wait \
+          --timeout 5m
+
+        echo "Déploiement terminé!"

--- a/tp6/tekton/tasks/kubectl-verify-task.yaml
+++ b/tp6/tekton/tasks/kubectl-verify-task.yaml
@@ -1,0 +1,33 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kubectl-verify
+  namespace: default
+spec:
+  description: Vérification du déploiement
+  params:
+    - name: deployment-name
+      type: string
+    - name: namespace
+      type: string
+      default: default
+  steps:
+    - name: verify-deployment
+      image: bitnami/kubectl:latest
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Vérification du rollout..."
+        kubectl rollout status deployment/$(params.deployment-name) -n $(params.namespace)
+
+        echo "Liste des pods:"
+        kubectl get pods -n $(params.namespace)
+
+    - name: smoke-test
+      image: curlimages/curl:latest
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Exécution des smoke tests..."
+        # Ajouter vos tests ici
+        echo "Tests terminés!"

--- a/tp6/tekton/tasks/npm-test-task.yaml
+++ b/tp6/tekton/tasks/npm-test-task.yaml
@@ -1,0 +1,40 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: npm-test
+  namespace: default
+spec:
+  description: Exécute les tests npm
+  workspaces:
+    - name: source
+  params:
+    - name: node-version
+      type: string
+      default: "18"
+  steps:
+    - name: install-dependencies
+      image: node:$(params.node-version)-alpine
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Installation des dépendances..."
+        npm ci
+
+    - name: run-tests
+      image: node:$(params.node-version)-alpine
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Exécution des tests..."
+        npm test
+
+    - name: lint
+      image: node:$(params.node-version)-alpine
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Linting du code..."
+        npm run lint || echo "Pas de lint configuré"

--- a/tp6/tekton/tasks/trivy-scan-task.yaml
+++ b/tp6/tekton/tasks/trivy-scan-task.yaml
@@ -1,0 +1,20 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: trivy-scan
+  namespace: default
+spec:
+  description: Scan de sécurité avec Trivy
+  params:
+    - name: image
+      type: string
+      description: Image à scanner
+  steps:
+    - name: scan
+      image: aquasec/trivy:latest
+      script: |
+        #!/bin/sh
+        set -e
+        echo "Scan de sécurité de l'image..."
+        trivy image --severity HIGH,CRITICAL $(params.image) || true
+        echo "Scan terminé!"


### PR DESCRIPTION
- Ajout du document ALTERNATIVE_SANS_GITHUB.md avec guide complet Tekton
- Création de toutes les Tasks Tekton (git-clone, npm-test, docker-build, trivy-scan, helm-deploy, kubectl-verify)
- Création des Pipelines CI et CD avec Tekton
- Ajout d'exemples de PipelineRun pour CI et CD
- Script d'installation automatique install-tekton.sh
- Mise à jour du README principal avec mention de l'alternative
- Documentation complète pour les utilisateurs sans compte GitHub

Cette alternative permet de faire du CI/CD Kubernetes-native avec Tekton, sans avoir besoin de créer un compte sur GitHub ou tout autre service externe.