### PR TITLE
Add kubeadm documentation to TP1 section 7.4

### DIFF
--- a/tp1/README.md
+++ b/tp1/README.md
@@ -648,10 +648,27 @@ kubectl get deployments,services,pods
 
 ### 7.4 Tester l'application
 
+#### Option A : Avec minikube
+
 ```bash
 # Accéder au service
 curl http://$(minikube ip):30080
 ```
+
+#### Option B : Avec kubeadm
+
+```bash
+# Récupérer l'IP d'un nœud
+export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+
+# Tester l'accès
+curl http://$NODE_IP:30080
+
+# Ou depuis un autre serveur sur le réseau
+# curl http://<IP-du-noeud>:30080
+```
+
+**Note :** Avec kubeadm, le service est accessible sur le port 30080 depuis n'importe quel nœud du cluster grâce à kube-proxy.
 
 ## Partie 8 : Nettoyage et commandes utiles
 


### PR DESCRIPTION
- Ajout des commandes pour tester l'application avec kubeadm
- Section 7.4 maintenant complète pour minikube et kubeadm
- Note explicative sur l'accessibilité du service avec kube-proxy