### PR TITLE
Verify TP2 exercise 4.2 deployment prerequisites

### DIFF
--- a/tp2/README.md
+++ b/tp2/README.md
@@ -213,10 +213,12 @@ spec:
   selector:
     matchLabels:      # DOIT correspondre aux labels du template
       app: web
+      env: prod
   template:           # Template du Pod
     metadata:
       labels:
         app: web
+        env: prod
     spec:
       containers:
       - name: nginx
@@ -352,11 +354,7 @@ spec:
   - name: http
     protocol: TCP
     port: 80
-    targetPort: 8080
-  - name: https
-    protocol: TCP
-    port: 443
-    targetPort: 8443
+    targetPort: 80
   sessionAffinity: ClientIP  # Maintenir la session sur le même pod
 ```
 


### PR DESCRIPTION
Problèmes corrigés :
- Ajout du label 'env: prod' au deployment web-deployment (04-deployment-basic.yaml) pour correspondre au selector du service app-service (08-service-complete.yaml)
- Correction du targetPort du service app-service de 8080 à 80 pour correspondre au containerPort du deployment nginx
- Suppression du port HTTPS (443) non applicable au deployment de base

Ces corrections assurent que l'exercice 6 fonctionne correctement et que tous les services trouvent leurs pods cibles correspondants.