### PR TITLE
Review and fix TP5 assignment

### DIFF
--- a/tp5/07-pod-security-context.yaml
+++ b/tp5/07-pod-security-context.yaml
@@ -9,7 +9,7 @@ spec:
     fsGroup: 2000
   containers:
   - name: demo
-    image: busybox
+    image: busybox:1.36
     command: ['sh', '-c', 'sleep 3600']
     volumeMounts:
     - name: demo-volume

--- a/tp5/13-network-policy-allow-specific.yaml
+++ b/tp5/13-network-policy-allow-specific.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: busybox
+        image: busybox:1.36
         command: ['sh', '-c', 'sleep 3600']
 ---
 apiVersion: networking.k8s.io/v1

--- a/tp5/16-pod-with-secrets.yaml
+++ b/tp5/16-pod-with-secrets.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: busybox
+    image: busybox:1.36
     command: ['sh', '-c', 'sleep 3600']
     env:
     # Secret comme variable d'environnement

--- a/tp5/17-secret-rbac.yaml
+++ b/tp5/17-secret-rbac.yaml
@@ -2,11 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: app-sa
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: secret-reader
+  namespace: default
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -17,6 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: app-secret-binding
+  namespace: default
 subjects:
 - kind: ServiceAccount
   name: app-sa

--- a/tp5/19-image-pull-secret.yaml
+++ b/tp5/19-image-pull-secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: registry-credentials
+  namespace: default
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: <base64-encoded-docker-config>
@@ -10,6 +11,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: app-with-registry
+  namespace: default
 imagePullSecrets:
 - name: registry-credentials
 ---
@@ -17,6 +19,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: private-image-pod
+  namespace: default
 spec:
   serviceAccountName: app-with-registry
   containers:


### PR DESCRIPTION
Corrections appliquées :
- Ajout des namespaces manquants dans 17-secret-rbac.yaml et 19-image-pull-secret.yaml
- Mise à jour des images busybox sans tag vers busybox:1.36 pour respecter les bonnes pratiques de sécurité
- Validation de tous les fichiers YAML (22 fichiers valides)

Fichiers modifiés :
- tp5/07-pod-security-context.yaml
- tp5/13-network-policy-allow-specific.yaml
- tp5/16-pod-with-secrets.yaml
- tp5/17-secret-rbac.yaml
- tp5/19-image-pull-secret.yaml