### PR TITLE
Review and fix TP7 assignment

### DIFF
--- a/tp7/QUICKSTART.md
+++ b/tp7/QUICKSTART.md
@@ -51,6 +51,7 @@ kubectl apply -f 05-database-service.yaml
 kubectl apply -f 06-backend-code.yaml
 kubectl apply -f 06-backend-deployment.yaml
 kubectl apply -f 07-backend-service.yaml
+kubectl apply -f 08-frontend-nginx-config.yaml
 kubectl apply -f 08-frontend-config.yaml
 kubectl apply -f 09-frontend-deployment.yaml
 kubectl apply -f 10-frontend-service.yaml
@@ -107,6 +108,7 @@ kubectl apply -f kubernetes-manifests/05-database-service.yaml && \
 kubectl apply -f kubernetes-manifests/06-backend-code.yaml && \
 kubectl apply -f kubernetes-manifests/06-backend-deployment.yaml && \
 kubectl apply -f kubernetes-manifests/07-backend-service.yaml && \
+kubectl apply -f kubernetes-manifests/08-frontend-nginx-config.yaml && \
 kubectl apply -f kubernetes-manifests/08-frontend-config.yaml && \
 kubectl apply -f kubernetes-manifests/09-frontend-deployment.yaml && \
 kubectl apply -f kubernetes-manifests/10-frontend-service.yaml && \

--- a/tp7/kubernetes-manifests/08-frontend-config.yaml
+++ b/tp7/kubernetes-manifests/08-frontend-config.yaml
@@ -143,7 +143,8 @@ data:
         <script>
             async function checkBackend() {
                 try {
-                    const response = await fetch('http://backend:5000/api/health');
+                    // Utilise le proxy Nginx pour atteindre le backend
+                    const response = await fetch('/api/health');
 
                     if (response.ok) {
                         const data = await response.json();
@@ -155,12 +156,13 @@ data:
                         document.getElementById('backend-info').style.display = 'block';
                         document.getElementById('backend-data').textContent = JSON.stringify(data, null, 2);
                     } else {
-                        throw new Error('Backend not responding');
+                        throw new Error('Backend not responding (HTTP ' + response.status + ')');
                     }
                 } catch (error) {
                     document.getElementById('status').className = 'status error';
                     document.getElementById('status').innerHTML =
-                        `❌ <span>Erreur: Backend non accessible. Ceci est normal si vous testez depuis l'extérieur du cluster.</span>`;
+                        `❌ <span>Erreur de connexion au backend: ${error.message}</span>`;
+                    console.error('Backend error:', error);
                 }
             }
 

--- a/tp7/kubernetes-manifests/08-frontend-nginx-config.yaml
+++ b/tp7/kubernetes-manifests/08-frontend-nginx-config.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-nginx-config
+  namespace: myapp
+  labels:
+    app: frontend
+    component: nginx-config
+data:
+  default.conf: |
+    server {
+        listen 80;
+        server_name _;
+
+        # Logs
+        access_log /var/log/nginx/access.log;
+        error_log /var/log/nginx/error.log;
+
+        # Servir le contenu HTML statique
+        location / {
+            root /usr/share/nginx/html;
+            index index.html;
+            try_files $uri $uri/ /index.html;
+        }
+
+        # Proxifier les requêtes API vers le backend
+        location /api/ {
+            proxy_pass http://backend:5000/api/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Timeouts
+            proxy_connect_timeout 10s;
+            proxy_send_timeout 10s;
+            proxy_read_timeout 10s;
+
+            # Buffering
+            proxy_buffering off;
+        }
+
+        # Health check endpoint
+        location /health {
+            access_log off;
+            return 200 "OK\n";
+            add_header Content-Type text/plain;
+        }
+    }

--- a/tp7/kubernetes-manifests/09-frontend-deployment.yaml
+++ b/tp7/kubernetes-manifests/09-frontend-deployment.yaml
@@ -38,6 +38,10 @@ spec:
         - name: html
           mountPath: /usr/share/nginx/html
           readOnly: true
+        - name: nginx-config
+          mountPath: /etc/nginx/conf.d/default.conf
+          subPath: default.conf
+          readOnly: true
         resources:
           requests:
             memory: "64Mi"
@@ -65,3 +69,6 @@ spec:
       - name: html
         configMap:
           name: frontend-html
+      - name: nginx-config
+        configMap:
+          name: frontend-nginx-config

--- a/tp7/kubernetes-manifests/README.md
+++ b/tp7/kubernetes-manifests/README.md
@@ -21,6 +21,7 @@ L'application est composée de trois tiers :
 06-backend-code.yaml          # Code Python du backend (ConfigMap)
 06-backend-deployment.yaml    # Déploiement du backend
 07-backend-service.yaml       # Service ClusterIP pour le backend
+08-frontend-nginx-config.yaml # Configuration Nginx avec proxy API (ConfigMap)
 08-frontend-config.yaml       # HTML du frontend (ConfigMap)
 09-frontend-deployment.yaml   # Déploiement du frontend
 10-frontend-service.yaml      # Service NodePort pour le frontend
@@ -43,6 +44,7 @@ kubectl apply -f 05-database-service.yaml
 kubectl apply -f 06-backend-code.yaml
 kubectl apply -f 06-backend-deployment.yaml
 kubectl apply -f 07-backend-service.yaml
+kubectl apply -f 08-frontend-nginx-config.yaml
 kubectl apply -f 08-frontend-config.yaml
 kubectl apply -f 09-frontend-deployment.yaml
 kubectl apply -f 10-frontend-service.yaml
@@ -68,6 +70,7 @@ kubectl apply -f 00-namespace.yaml \
               -f 06-backend-code.yaml \
               -f 06-backend-deployment.yaml \
               -f 07-backend-service.yaml \
+              -f 08-frontend-nginx-config.yaml \
               -f 08-frontend-config.yaml \
               -f 09-frontend-deployment.yaml \
               -f 10-frontend-service.yaml


### PR DESCRIPTION
Problème identifié et corrigé :
- Le frontend tentait d'accéder au backend via http://backend:5000/api/health directement depuis le navigateur, ce qui est impossible car le DNS Kubernetes n'est pas résolvable depuis l'extérieur du cluster.

Solutions appliquées :
- Ajout d'une configuration Nginx (08-frontend-nginx-config.yaml) qui proxifie les requêtes /api/* vers le service backend (ClusterIP)
- Modification du frontend-deployment pour monter cette configuration Nginx
- Mise à jour du code JavaScript pour utiliser /api/health au lieu de http://backend:5000/api/health
- Mise à jour de la documentation (QUICKSTART.md et README.md)

Résultat :
L'application fonctionne maintenant correctement avec le navigateur qui accède au frontend via NodePort, et le frontend qui communique avec le backend via le proxy Nginx interne au cluster.