### PR TITLE
Review and fix TP9 assignment

### DIFF
--- a/tp9/exercices/exercice4-autoscaling.yaml
+++ b/tp9/exercices/exercice4-autoscaling.yaml
@@ -1,0 +1,254 @@
+# Exercice 4 : Auto-scaling et gestion de charge
+# Objectif : Configurer l'auto-scaling et gérer la charge sur les nœuds
+
+# Instructions :
+# 1. Installer Metrics Server (si pas déjà installé) :
+#    kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+#
+#    Pour minikube ou clusters de test :
+#    kubectl patch deployment metrics-server -n kube-system --type='json' \
+#      -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kubelet-insecure-tls"}]'
+#
+# 2. Appliquer ce fichier : kubectl apply -f exercice4-autoscaling.yaml
+#
+# 3. Attendre que le deployment soit prêt : kubectl wait --for=condition=available deployment/php-apache -n autoscaling-exercise
+#
+# 4. Générer de la charge (dans un terminal séparé) :
+#    kubectl run -it --rm load-generator --image=busybox --restart=Never -n autoscaling-exercise -- /bin/sh
+#    # Dans le pod :
+#    while true; do wget -q -O- http://php-apache; done
+#
+# 5. Observer l'auto-scaling (dans un autre terminal) :
+#    watch kubectl get hpa -n autoscaling-exercise
+#    watch kubectl get pods -n autoscaling-exercise -o wide
+#
+# 6. Observer la répartition sur les nœuds :
+#    kubectl top nodes
+#    kubectl top pods -n autoscaling-exercise
+#
+# 7. Arrêter la charge (Ctrl+C dans le terminal du load-generator)
+#    et observer le scale down après 5 minutes
+
+---
+# Namespace pour l'exercice
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: autoscaling-exercise
+
+---
+# Application de test - PHP Apache consommant du CPU
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: php-apache
+  namespace: autoscaling-exercise
+  labels:
+    app: php-apache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: php-apache
+  template:
+    metadata:
+      labels:
+        app: php-apache
+    spec:
+      containers:
+      - name: php-apache
+        image: registry.k8s.io/hpa-example
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 200m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+
+---
+# Service pour exposer l'application
+apiVersion: v1
+kind: Service
+metadata:
+  name: php-apache
+  namespace: autoscaling-exercise
+spec:
+  selector:
+    app: php-apache
+  ports:
+  - port: 80
+    targetPort: 80
+  type: ClusterIP
+
+---
+# HorizontalPodAutoscaler - Scale entre 1 et 10 replicas
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache-hpa
+  namespace: autoscaling-exercise
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50  # Cible 50% d'utilisation CPU
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300  # Attendre 5 min avant de scale down
+      policies:
+      - type: Percent
+        value: 50
+        periodSeconds: 60
+      - type: Pods
+        value: 2
+        periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0  # Scale up immédiatement
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 15
+      - type: Pods
+        value: 4
+        periodSeconds: 15
+      selectPolicy: Max
+
+---
+# PodDisruptionBudget pour protéger pendant l'auto-scaling
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: php-apache-pdb
+  namespace: autoscaling-exercise
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: php-apache
+
+---
+# Exemple de Pod Anti-Affinity pour répartir sur différents nœuds
+# (Décommenter pour tester la répartition géographique)
+# apiVersion: apps/v1
+# kind: Deployment
+# metadata:
+#   name: php-apache-distributed
+#   namespace: autoscaling-exercise
+# spec:
+#   replicas: 1
+#   selector:
+#     matchLabels:
+#       app: php-apache-distributed
+#   template:
+#     metadata:
+#       labels:
+#         app: php-apache-distributed
+#     spec:
+#       affinity:
+#         podAntiAffinity:
+#           preferredDuringSchedulingIgnoredDuringExecution:
+#           - weight: 100
+#             podAffinityTerm:
+#               labelSelector:
+#                 matchExpressions:
+#                 - key: app
+#                   operator: In
+#                   values:
+#                   - php-apache-distributed
+#               topologyKey: kubernetes.io/hostname
+#       containers:
+#       - name: php-apache
+#         image: registry.k8s.io/hpa-example
+#         ports:
+#         - containerPort: 80
+#         resources:
+#           requests:
+#             cpu: 200m
+#             memory: 128Mi
+#           limits:
+#             cpu: 500m
+#             memory: 256Mi
+
+---
+# ConfigMap avec script de génération de charge avancé
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: load-generator-script
+  namespace: autoscaling-exercise
+data:
+  load-test.sh: |
+    #!/bin/sh
+    echo "=== Générateur de charge pour HPA ==="
+    echo "Target: http://php-apache"
+    echo "Démarrage dans 5 secondes..."
+    sleep 5
+
+    echo "Génération de charge... (Ctrl+C pour arrêter)"
+    while true; do
+      wget -q -O- http://php-apache > /dev/null 2>&1
+      sleep 0.01  # 100 requêtes/seconde
+    done
+
+# Commandes de vérification et de monitoring :
+#
+# 1. Vérifier que Metrics Server fonctionne :
+#    kubectl top nodes
+#    kubectl top pods -n autoscaling-exercise
+#
+# 2. Voir l'état du HPA :
+#    kubectl get hpa -n autoscaling-exercise
+#    kubectl describe hpa php-apache-hpa -n autoscaling-exercise
+#
+# 3. Générer de la charge (méthode 1 - simple) :
+#    kubectl run -it --rm load-generator --image=busybox --restart=Never -n autoscaling-exercise -- /bin/sh -c "while true; do wget -q -O- http://php-apache; done"
+#
+# 4. Générer de la charge (méthode 2 - avec script) :
+#    kubectl run -it --rm load-generator --image=busybox --restart=Never -n autoscaling-exercise --command -- /bin/sh
+#    # Puis dans le pod :
+#    while true; do wget -q -O- http://php-apache; done
+#
+# 5. Générer de la charge (méthode 3 - multiple pods) :
+#    for i in {1..5}; do
+#      kubectl run load-generator-$i --image=busybox -n autoscaling-exercise -- /bin/sh -c "while true; do wget -q -O- http://php-apache; done" &
+#    done
+#
+# 6. Observer l'auto-scaling en temps réel :
+#    watch -n 1 "kubectl get hpa -n autoscaling-exercise; echo ''; kubectl get pods -n autoscaling-exercise"
+#
+# 7. Voir les événements HPA :
+#    kubectl get events -n autoscaling-exercise --sort-by='.lastTimestamp' | grep HorizontalPodAutoscaler
+#
+# 8. Vérifier la répartition sur les nœuds :
+#    kubectl get pods -n autoscaling-exercise -o wide
+#    kubectl top nodes
+#
+# 9. Nettoyer les load generators :
+#    kubectl delete pod -n autoscaling-exercise -l run=load-generator
+#
+# 10. Supprimer complètement l'exercice :
+#     kubectl delete namespace autoscaling-exercise
+#
+# Résultats attendus :
+# - Après génération de charge, le nombre de replicas augmente (max 10)
+# - Les pods sont répartis sur différents nœuds (si cluster multi-nœuds)
+# - Après arrêt de la charge, le nombre de replicas diminue après 5 minutes (minReplicas: 1)
+# - Le PDB protège contre la suppression trop rapide de pods
+#
+# Métriques à observer :
+# - CPU utilization du deployment
+# - Nombre de replicas actifs
+# - Temps de réponse du service
+# - Distribution sur les nœuds


### PR DESCRIPTION
Correction d'un problème identifié lors de la vérification du TP9 :
- Le README mentionnait l'exercice 4 (auto-scaling) mais le fichier n'existait pas
- Création de exercices/exercice4-autoscaling.yaml avec :
  * Deployment PHP Apache pour tester l'auto-scaling
  * Service pour exposer l'application
  * HorizontalPodAutoscaler (HPA) configuré
  * PodDisruptionBudget pour la protection
  * Instructions détaillées pour générer de la charge
  * Commandes de monitoring et de vérification
  * 6 ressources Kubernetes complètes

Le fichier suit le même format et style que les autres exercices du TP9.