### PR TITLE
Review and fix TP8 assignment

### DIFF
--- a/tp8/examples/07-networkpolicy-egress-dns.yaml
+++ b/tp8/examples/07-networkpolicy-egress-dns.yaml
@@ -1,7 +1,7 @@
 # NetworkPolicy : Allow egress DNS uniquement
 # Utilisation : kubectl create namespace restricted
 #               kubectl apply -f 07-networkpolicy-egress-dns.yaml
-# Test : Résolution DNS fonctionne, HTTP/HTTPS bloqué
+# Test : Résolution DNS fonctionne (UDP et TCP), HTTP/HTTPS bloqué
 
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -13,11 +13,9 @@ spec:
   policyTypes:
   - Egress
   egress:
-  # Allow DNS (UDP port 53)
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          name: kube-system
-    ports:
+  # Allow DNS (UDP and TCP port 53)
+  - ports:
     - protocol: UDP
+      port: 53
+    - protocol: TCP
       port: 53

--- a/tp8/exercices/exercice-1-multi-tiers.yaml
+++ b/tp8/exercices/exercice-1-multi-tiers.yaml
@@ -82,7 +82,7 @@ spec:
       - name: api
         image: nginx:alpine
         ports:
-        - containerPort: 8080
+        - containerPort: 80
         resources:
           requests:
             cpu: 100m
@@ -100,7 +100,7 @@ spec:
     app: backend
   ports:
   - port: 8080
-    targetPort: 8080
+    targetPort: 80
 
 ---
 # Database Deployment

--- a/tp8/exercices/exercice-2-networkpolicies.yaml
+++ b/tp8/exercices/exercice-2-networkpolicies.yaml
@@ -63,7 +63,7 @@ spec:
           tier: frontend
     ports:
     - protocol: TCP
-      port: 8080
+      port: 80
 
 ---
 # NetworkPolicy 4 : Allow Database ingress from Backend only
@@ -88,13 +88,11 @@ spec:
     - protocol: TCP
       port: 5432
   egress:
-  # Allow DNS
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-    ports:
+  # Allow DNS (UDP and TCP)
+  - ports:
     - protocol: UDP
+      port: 53
+    - protocol: TCP
       port: 53
 
 ---
@@ -109,12 +107,11 @@ spec:
   policyTypes:
   - Egress
   egress:
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-    ports:
+  # Allow DNS (UDP and TCP)
+  - ports:
     - protocol: UDP
+      port: 53
+    - protocol: TCP
       port: 53
   # Allow communication within namespace
   - to:


### PR DESCRIPTION
- Correction du port du backend dans exercice-1-multi-tiers.yaml : Le conteneur nginx écoute sur le port 80, pas 8080. Modifié containerPort de 8080 à 80 et targetPort du service en conséquence.

- Correction des NetworkPolicies dans exercice-2-networkpolicies.yaml : Ajusté le port backend de 8080 à 80 pour correspondre au changement ci-dessus.

- Amélioration des règles DNS dans les NetworkPolicies : Supprimé la dépendance au label kubernetes.io/metadata.name pour kube-system. Les règles DNS autorisent maintenant le trafic vers le port 53 (UDP et TCP) sans restriction de namespace, ce qui est plus robuste et fonctionne sur toutes les versions de Kubernetes.