### PR TITLE
TP4: Correction des permissions RBAC Prometheus

### DIFF
--- a/tp4/04-prometheus-deployment.yaml
+++ b/tp4/04-prometheus-deployment.yaml
@@ -137,12 +137,18 @@ rules:
   resources:
   - nodes
   - nodes/proxy
+  - nodes/metrics
   - services
   - endpoints
   - pods
+  - namespaces
   verbs: ["get", "list", "watch"]
+- nonResourceURLs:
+  - /metrics
+  - /metrics/cadvisor
+  verbs: ["get"]
 - apiGroups:
-  - extensions
+  - networking.k8s.io
   resources:
   - ingresses
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Problème
Les permissions RBAC de Prometheus étaient incomplètes, empêchant la collecte de métriques. Les targets kubernetes-nodes et kubernetes-cadvisor étaient DOWN avec des erreurs 403 Forbidden.

## Corrections apportées

### 1. Ajout de permissions RBAC manquantes dans le ClusterRole :
- `nodes/metrics` : Accès aux métriques kubelet
- `namespaces` : Service discovery des namespaces
- `nonResourceURLs` (/metrics, /metrics/cadvisor) : Accès aux endpoints de métriques
- Migration de `extensions` vers `networking.k8s.io` pour les ingresses (API non dépréciée)

### 2. Documentation améliorée dans le README :
- Ajout d'une note explicative sur les permissions RBAC nécessaires
- Tableau récapitulatif des permissions et leurs usages
- Section de diagnostic des problèmes RBAC étendue avec :
  * Commandes `kubectl auth can-i` pour tester les permissions
  * Détection des erreurs 403/401 dans les logs
  * Tableau des erreurs courantes et solutions
- Checklist de vérification mise à jour avec les validations RBAC

### 3. Mise à jour du YAML dans le README :
- Le ClusterRole affiché dans le README correspond maintenant au fichier corrigé

## Impact
Ces corrections permettent à Prometheus de :
✅ Collecter les métriques cAdvisor (CPU, mémoire des conteneurs) ✅ Découvrir automatiquement les nœuds et pods
✅ Accéder aux endpoints /metrics et /metrics/cadvisor ✅ Fonctionner sans erreurs 403 Forbidden

## Fichiers modifiés
- tp4/04-prometheus-deployment.yaml : ClusterRole corrigé
- tp4/README.md : Documentation et diagnostic RBAC améliorés