### PR TITLE
Fix Prometheus endpoints returning 404 errors

### DIFF
--- a/tp4/04-prometheus-deployment.yaml
+++ b/tp4/04-prometheus-deployment.yaml
@@ -61,6 +61,31 @@ data:
       - job_name: 'kubernetes-service-endpoints'
         kubernetes_sd_configs:
           - role: endpoints
+        relabel_configs:
+          # Ne garder que les services annotés avec prometheus.io/scrape=true
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          # Utiliser le chemin spécifié dans l'annotation prometheus.io/path (par défaut /metrics)
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          # Utiliser le port spécifié dans l'annotation prometheus.io/port
+          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          # Copier les labels du service
+          - action: labelmap
+            regex: __meta_kubernetes_service_label_(.+)
+          # Ajouter le namespace comme label
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: kubernetes_namespace
+          # Ajouter le nom du service comme label
+          - source_labels: [__meta_kubernetes_service_name]
+            target_label: kubernetes_name
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tp4/06-instrumented-app.yaml
+++ b/tp4/06-instrumented-app.yaml
@@ -29,6 +29,10 @@ kind: Service
 metadata:
   name: demo-app
   namespace: monitoring
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
+    prometheus.io/path: "/metrics"
 spec:
   selector:
     app: demo-app

--- a/tp4/07-prometheus-with-rules.yaml
+++ b/tp4/07-prometheus-with-rules.yaml
@@ -59,6 +59,31 @@ data:
       - job_name: 'kubernetes-service-endpoints'
         kubernetes_sd_configs:
           - role: endpoints
+        relabel_configs:
+          # Ne garder que les services annotés avec prometheus.io/scrape=true
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          # Utiliser le chemin spécifié dans l'annotation prometheus.io/path (par défaut /metrics)
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          # Utiliser le port spécifié dans l'annotation prometheus.io/port
+          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          # Copier les labels du service
+          - action: labelmap
+            regex: __meta_kubernetes_service_label_(.+)
+          # Ajouter le namespace comme label
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: kubernetes_namespace
+          # Ajouter le nom du service comme label
+          - source_labels: [__meta_kubernetes_service_name]
+            target_label: kubernetes_name
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Le job kubernetes-service-endpoints tentait de scraper tous les endpoints de services sans filtrage, causant des centaines d'erreurs HTTP 404 sur les services système (kube-dns, kube-apiserver, etc.) qui n'exposent pas de métriques Prometheus.

Modifications:
- Ajout des relabel_configs au job kubernetes-service-endpoints pour filtrer uniquement les services annotés avec prometheus.io/scrape=true
- Configuration des annotations prometheus.io/port et prometheus.io/path
- Mise à jour de demo-app service avec les annotations appropriées
- Documentation explicative sur l'importance de cette configuration

Fichiers modifiés:
- tp4/04-prometheus-deployment.yaml: Configuration relabel_configs
- tp4/07-prometheus-with-rules.yaml: Configuration relabel_configs
- tp4/06-instrumented-app.yaml: Annotations sur le Service
- tp4/README.md: Documentation et explications