### PR TITLE
Fix failing test in CI pipeline

### DIFF
--- a/.github/workflows/test-kubernetes-manifests.yml
+++ b/.github/workflows/test-kubernetes-manifests.yml
@@ -449,6 +449,9 @@ jobs:
   security-scan:
     name: Security Scanning
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Le job security-scan échouait car il n'avait pas les permissions nécessaires pour uploader les résultats SARIF vers CodeQL. Ajout de security-events: write et contents: read pour résoudre l'erreur "Resource not accessible by integration".