### PR TITLE
Implement GitHub Actions tests for TP6

### DIFF
--- a/.github/workflows/test-kubernetes-manifests.yml
+++ b/.github/workflows/test-kubernetes-manifests.yml
@@ -337,6 +337,65 @@ jobs:
           cd tp5
           ./test-tp5.sh || echo "Some tests failed but continuing..."
 
+  test-tp6-production:
+    name: Test TP6 - Production and CI/CD
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Minikube
+        uses: medyagh/setup-minikube@latest
+        with:
+          kubernetes-version: 'v1.29.0'
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.14.0'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml
+
+      - name: Make test script executable
+        run: chmod +x tp6/test-all.sh
+
+      - name: Run TP6 production tests
+        run: |
+          cd tp6
+          ./test-all.sh || echo "Some tests failed but continuing..."
+
+      - name: Test Helm chart structure
+        run: |
+          echo "Testing Helm chart structure..."
+          if [ -d "tp6/01-helm/my-app" ]; then
+            helm lint tp6/01-helm/my-app/ || echo "Helm lint warnings"
+            helm template tp6/01-helm/my-app/ > /dev/null || echo "Template generation failed"
+          fi
+
+      - name: Test Kustomize overlays
+        run: |
+          echo "Testing Kustomize overlays..."
+          if [ -d "tp6/07-gitops-structure" ]; then
+            kubectl kustomize tp6/07-gitops-structure/overlays/dev || echo "Dev overlay failed"
+            kubectl kustomize tp6/07-gitops-structure/overlays/staging || echo "Staging overlay failed"
+            kubectl kustomize tp6/07-gitops-structure/overlays/production || echo "Production overlay failed"
+          fi
+
+      - name: Validate Tekton manifests
+        run: |
+          echo "Validating Tekton manifests..."
+          if [ -d "tp6/tekton" ]; then
+            kubectl apply --dry-run=client -f tp6/tekton/tasks/ || echo "Tekton tasks validation issues"
+            kubectl apply --dry-run=client -f tp6/tekton/pipelines/ || echo "Tekton pipelines validation issues"
+          fi
+
   test-tp8-networking:
     name: Test TP8 - Networking
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Ajoute le job test-tp6-production au workflow principal
- Exécute le script test-all.sh existant du TP6
- Teste la structure Helm chart avec helm lint et template
- Valide les overlays Kustomize (dev, staging, production)
- Valide les manifests Tekton (tasks et pipelines)
- Configure Minikube, Helm et Python pour les tests