### PR TITLE
Add concrete examples for service types

### DIFF
--- a/tp1/architecture-complete.yaml
+++ b/tp1/architecture-complete.yaml
@@ -1,0 +1,115 @@
+# Exemple d'architecture complète à 3 tiers
+# Frontend (LoadBalancer) -> Backend API (ClusterIP) -> Database (ClusterIP)
+# Démontre l'utilisation appropriée de chaque type de service
+
+# Base de données (ClusterIP - interne uniquement)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: database
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: db
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:15-alpine
+        env:
+        - name: POSTGRES_PASSWORD
+          value: "secretpassword"
+        - name: POSTGRES_DB
+          value: "appdb"
+        ports:
+        - containerPort: 5432
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: database-service
+spec:
+  type: ClusterIP  # Accessible uniquement depuis le cluster
+  selector:
+    app: db
+  ports:
+  - port: 5432
+    targetPort: 5432
+---
+# Backend API (ClusterIP - appelé par le frontend)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - name: api
+        image: httpd:2.4-alpine  # Remplacer par votre API réelle
+        ports:
+        - containerPort: 80
+        env:
+        - name: DATABASE_HOST
+          value: "database-service"  # Utilise le nom du service
+        - name: DATABASE_PORT
+          value: "5432"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-api-service
+spec:
+  type: ClusterIP  # Interne, appelé uniquement par le frontend
+  selector:
+    app: api
+  ports:
+  - port: 8080
+    targetPort: 80
+---
+# Frontend (LoadBalancer - accessible publiquement)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - containerPort: 80
+        env:
+        - name: API_URL
+          value: "http://backend-api-service:8080"  # Utilise le nom du service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-service
+spec:
+  type: LoadBalancer  # Accessible depuis Internet
+  selector:
+    app: frontend
+  ports:
+  - port: 80
+    targetPort: 80

--- a/tp1/frontend-loadbalancer.yaml
+++ b/tp1/frontend-loadbalancer.yaml
@@ -1,0 +1,67 @@
+# Exemple de Service LoadBalancer - Frontend web en production
+# Ce service obtient une IP publique via le cloud provider
+# Cas d'usage : Sites web publics, APIs REST publiques, applications SaaS
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-prod
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+      tier: web
+  template:
+    metadata:
+      labels:
+        app: frontend
+        tier: web
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.24-alpine
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "100m"
+          limits:
+            memory: "128Mi"
+            cpu: "200m"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-loadbalancer
+  annotations:
+    # Annotations spécifiques aux cloud providers (exemples)
+    # AWS ELB
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    # GCP
+    cloud.google.com/load-balancer-type: "External"
+    # Azure
+    service.beta.kubernetes.io/azure-load-balancer-internal: "false"
+spec:
+  type: LoadBalancer
+  selector:
+    app: frontend
+    tier: web
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+  sessionAffinity: ClientIP  # Optionnel : maintenir les sessions utilisateur

--- a/tp1/redis-clusterip.yaml
+++ b/tp1/redis-clusterip.yaml
@@ -1,0 +1,39 @@
+# Exemple de Service ClusterIP - Base de données Redis
+# Ce service est accessible uniquement depuis l'intérieur du cluster
+# Cas d'usage : Backend database, cache interne, message queue
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        tier: backend
+    spec:
+      containers:
+      - name: redis
+        image: redis:7-alpine
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-service
+spec:
+  type: ClusterIP  # Accessible uniquement depuis l'intérieur du cluster
+  selector:
+    app: redis
+    tier: backend
+  ports:
+  - protocol: TCP
+    port: 6379
+    targetPort: 6379

--- a/tp1/webapp-nodeport.yaml
+++ b/tp1/webapp-nodeport.yaml
@@ -1,0 +1,70 @@
+# Exemple de Service NodePort - Application de développement
+# Ce service est accessible depuis l'extérieur via <NodeIP>:<NodePort>
+# Cas d'usage : Applications dev/test, débogage, démos
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webapp-dev
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: webapp
+      env: dev
+  template:
+    metadata:
+      labels:
+        app: webapp
+        env: dev
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: html
+          mountPath: /usr/share/nginx/html
+      volumes:
+      - name: html
+        configMap:
+          name: webapp-html
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: webapp-html
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html>
+    <head><title>Application de Développement</title></head>
+    <body>
+      <h1>🚀 Application NodePort</h1>
+      <p>Cette application est exposée via NodePort et accessible depuis l'extérieur du cluster.</p>
+      <p>Hostname: <span id="hostname"></span></p>
+      <script>
+        fetch('/hostname.txt').then(r => r.text()).then(h => {
+          document.getElementById('hostname').textContent = h || window.location.hostname;
+        }).catch(() => {
+          document.getElementById('hostname').textContent = window.location.hostname;
+        });
+      </script>
+    </body>
+    </html>
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webapp-nodeport
+spec:
+  type: NodePort
+  selector:
+    app: webapp
+    env: dev
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+    nodePort: 30100  # Port fixe pour un accès prévisible


### PR DESCRIPTION
Enrichissement de la partie 5 du TP1 avec quatre exemples pratiques et déployables :

1. **Service ClusterIP** - Base de données Redis
   - Exemple de service interne uniquement accessible depuis le cluster
   - Cas d'usage : backend database, cache, message queue

2. **Service NodePort** - Application web de développement
   - Application accessible depuis l'extérieur via NodeIP:NodePort
   - Cas d'usage : développement, test, débogage

3. **Service LoadBalancer** - Frontend web en production
   - Application avec IP publique via cloud provider
   - Cas d'usage : sites web publics, APIs REST, applications SaaS

4. **Architecture complète à 3 tiers**
   - Frontend (LoadBalancer) -> Backend API (ClusterIP) -> Database (ClusterIP)
   - Démontre l'utilisation appropriée de chaque type de service

Chaque exemple inclut :
- Fichiers YAML complets et prêts à déployer
- Commandes de déploiement et de test
- Cas d'usage réels
- Schéma d'architecture pour l'exemple 3-tiers

Fichiers ajoutés :
- tp1/redis-clusterip.yaml
- tp1/webapp-nodeport.yaml
- tp1/frontend-loadbalancer.yaml
- tp1/architecture-complete.yaml