### PR TITLE
Fix Kubernetes security context for frontend deployment

### DIFF
--- a/tp1/architecture-complete.yaml
+++ b/tp1/architecture-complete.yaml
@@ -17,9 +17,18 @@ spec:
       labels:
         app: db
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        fsGroup: 999
       containers:
       - name: postgres
         image: postgres:15-alpine
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         env:
         - name: POSTGRES_PASSWORD
           value: "secretpassword"
@@ -55,9 +64,18 @@ spec:
       labels:
         app: api
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
       - name: api
         image: httpd:2.4-alpine  # Remplacer par votre API réelle
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         ports:
         - containerPort: 80
         env:
@@ -93,9 +111,18 @@ spec:
       labels:
         app: frontend
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
       containers:
       - name: nginx
         image: nginx:alpine
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         ports:
         - containerPort: 80
         env:


### PR DESCRIPTION
- Ajouter securityContext pour empêcher l'exécution en tant que root
- Frontend: utilise l'utilisateur nginx (UID 101)
- Backend API: utilise l'utilisateur 1000
- Database: utilise l'utilisateur postgres (UID 999)
- Désactiver allowPrivilegeEscalation et supprimer toutes les capabilities
- Résout la vulnérabilité HIGH KSV118 sur le déploiement frontend