### PR TITLE
Fix custom Chart creation issues in TP6

### DIFF
--- a/tp6/01-helm/my-app/templates/NOTES.txt
+++ b/tp6/01-helm/my-app/templates/NOTES.txt
@@ -1,0 +1,53 @@
+Merci d'avoir installé {{ .Chart.Name }} version {{ .Chart.Version }}.
+
+Votre release s'appelle {{ .Release.Name }}.
+
+Pour accéder à votre application :
+
+{{- if .Values.ingress.enabled }}
+
+  L'application est accessible via Ingress :
+  {{- range $host := .Values.ingress.hosts }}
+    http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ (index $host.paths 0).path }}
+  {{- end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "my-app.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "Application disponible sur http://$NODE_IP:$NODE_PORT"
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  REMARQUE: Le LoadBalancer peut prendre quelques minutes pour être prêt.
+           Surveillez le statut avec : kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "my-app.fullname" . }}
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "my-app.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo "Application disponible sur http://$SERVICE_IP:{{ .Values.service.port }}"
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+  Pour accéder à votre application depuis votre machine locale :
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "my-app.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visitez http://127.0.0.1:8080 pour utiliser votre application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+
+{{- end }}
+
+{{- if .Values.autoscaling.enabled }}
+
+L'autoscaling est activé :
+  - Minimum de réplicas : {{ .Values.autoscaling.minReplicas }}
+  - Maximum de réplicas : {{ .Values.autoscaling.maxReplicas }}
+  - Cible CPU : {{ .Values.autoscaling.targetCPUUtilizationPercentage }}%
+
+{{- else }}
+
+Nombre de réplicas : {{ .Values.replicaCount }}
+
+{{- end }}
+
+Pour voir les logs de votre application :
+  kubectl logs -f -l app.kubernetes.io/name={{ include "my-app.name" . }},app.kubernetes.io/instance={{ .Release.Name }} --namespace {{ .Release.Namespace }}

--- a/tp6/01-helm/my-app/templates/deployment.yaml
+++ b/tp6/01-helm/my-app/templates/deployment.yaml
@@ -16,10 +16,24 @@ spec:
       labels:
         {{- include "my-app.selectorLabels" . | nindent 8 }}
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 101
+          capabilities:
+            drop:
+            - ALL
         ports:
         - name: http
           containerPort: 80
@@ -28,9 +42,27 @@ spec:
           httpGet:
             path: /
             port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /
             port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: cache
+          mountPath: /var/cache/nginx
+        - name: run
+          mountPath: /var/run
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: cache
+        emptyDir: {}
+      - name: run
+        emptyDir: {}


### PR DESCRIPTION
…et documentation complète

Problèmes corrigés dans la section 1.4 :

1. **Fichier NOTES.txt manquant**
   - Créé templates/NOTES.txt avec instructions d'accès dynamiques
   - Affichage adapté selon le type de service (ClusterIP/NodePort/LoadBalancer/Ingress)
   - Informations sur l'autoscaling et les logs

2. **Security Context manquants dans deployment.yaml**
   - Ajout securityContext niveau pod : runAsNonRoot, fsGroup, seccompProfile
   - Ajout securityContext niveau container : readOnlyRootFilesystem, capabilities drop ALL
   - Ajout volumes emptyDir pour /tmp, /var/cache/nginx, /var/run
   - Ajout initialDelaySeconds et periodSeconds pour les probes

3. **Documentation incomplète dans README.md**
   - Ajout note de sécurité expliquant les configurations
   - Documentation des autres templates (_helpers.tpl, service.yaml, ingress.yaml, hpa.yaml)
   - Commandes pour consulter les templates générés par helm create

Conformité sécurité :
- ✅ runAsNonRoot: true (UID 101 pour nginx)
- ✅ readOnlyRootFilesystem: true
- ✅ allowPrivilegeEscalation: false
- ✅ capabilities: drop ALL
- ✅ seccompProfile: RuntimeDefault
- ✅ Volumes emptyDir pour répertoires en écriture

Le Chart est maintenant conforme aux standards de sécurité du projet.