### PR TITLE
fix(tp10): Corriger le CrashLoopBackOff du backend-api en ajoutant .l…

### DIFF
--- a/tp10/09-backend-deployment.yaml
+++ b/tp10/09-backend-deployment.yaml
@@ -35,6 +35,9 @@ spec:
           # Installer les dépendances en mode utilisateur
           pip install --user --no-cache-dir flask psycopg2-binary redis gunicorn
 
+          # Ajouter .local/bin au PATH pour accéder à gunicorn
+          export PATH=/home/nonroot/.local/bin:$PATH
+
           # Lancer l'application
           exec gunicorn --bind 0.0.0.0:5000 --workers 2 --timeout 60 app:app
         ports:


### PR DESCRIPTION
…ocal/bin au PATH

Le pod backend-api crashait avec exit code 127 (command not found) car gunicorn installé avec 'pip install --user' n'était pas dans le PATH.

Changements:
- Ajout de 'export PATH=/home/nonroot/.local/bin:$PATH' avant exec gunicorn
- Permet au shell de trouver gunicorn après installation en mode --user

Résout: Exit code 127 - /bin/bash: gunicorn: command not found