### PR TITLE
fix(tp10): Utiliser python -m gunicorn au lieu de l'exécutable gunicorn

### DIFF
--- a/tp10/09-backend-deployment.yaml
+++ b/tp10/09-backend-deployment.yaml
@@ -35,11 +35,8 @@ spec:
           # Installer les dépendances en mode utilisateur
           pip install --user --no-cache-dir flask psycopg2-binary redis gunicorn
 
-          # Ajouter .local/bin au PATH pour accéder à gunicorn
-          export PATH=/home/nonroot/.local/bin:$PATH
-
-          # Lancer l'application
-          exec gunicorn --bind 0.0.0.0:5000 --workers 2 --timeout 60 app:app
+          # Lancer l'application avec python -m (plus robuste que PATH)
+          exec python -m gunicorn --bind 0.0.0.0:5000 --workers 2 --timeout 60 app:app
         ports:
         - containerPort: 5000
           name: http


### PR DESCRIPTION
Le pod backend-api crashait toujours avec exit code 127 malgré l'ajout du PATH. Solution plus robuste : utiliser 'python -m gunicorn' qui ne dépend pas du PATH.

Changements:
- Remplacement de 'export PATH + exec gunicorn' par 'exec python -m gunicorn'
- Python trouve toujours ses modules installés via pip --user
- Évite les problèmes de PATH avec les exécutables

Résout: CrashLoopBackOff du backend-api (exit code 127)