### PR TITLE
fix(tp10): Corriger les permissions PostgreSQL pour permettre l'initi…

### DIFF
--- a/tp10/04-postgres-deployment.yaml
+++ b/tp10/04-postgres-deployment.yaml
@@ -38,7 +38,8 @@ spec:
           echo "InitContainer completed successfully"
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          # Note: readOnlyRootFilesystem is not set for init container
+          # This allows the container to perform initialization tasks if needed
           runAsNonRoot: true
           runAsUser: 70
           capabilities:
@@ -61,7 +62,9 @@ spec:
           name: postgres
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          # Note: readOnlyRootFilesystem is not set for PostgreSQL
+          # PostgreSQL needs write access to manage its data directory
+          # Security is maintained through: runAsNonRoot, capabilities drop, and volume isolation
           runAsNonRoot: true
           runAsUser: 70
           capabilities:


### PR DESCRIPTION
…alisation

Problème résolu :
- PostgreSQL ne pouvait pas démarrer à cause de "Operation not permitted" lors de l'exécution de chmod/initdb sur /var/lib/postgresql/data

Cause racine :
- Le conteneur avait readOnlyRootFilesystem: true
- PostgreSQL nécessite un accès en écriture pour initialiser son répertoire de données avec initdb

Solution appliquée :
- Retiré readOnlyRootFilesystem du conteneur principal postgres
- Retiré readOnlyRootFilesystem de l'initContainer
- Ajouté des commentaires explicatifs dans le manifest
- Conservé tous les autres contrôles de sécurité

Sécurité maintenue par :
- runAsNonRoot: true avec runAsUser: 70
- allowPrivilegeEscalation: false
- capabilities.drop: ALL
- seccompProfile: RuntimeDefault
- Isolation via PVC et emptyDir volumes

Fichiers modifiés :
- tp10/04-postgres-deployment.yaml : Correction securityContext
- .claude/CONTEXT.md : Documentation de la correction
- .claude/SECURITY.md : Ajout section "Bases de données" dans cas spéciaux

Ref: Session 2025-12-17