### PR TITLE
fix(tp10): Corriger le problème de subPath empêchant fsGroup de fonct…

### DIFF
--- a/tp10/04-postgres-deployment.yaml
+++ b/tp10/04-postgres-deployment.yaml
@@ -73,10 +73,14 @@ spec:
         envFrom:
         - secretRef:
             name: postgres-secret
+        env:
+        # PGDATA doit pointer vers un sous-répertoire pour permettre l'initialisation
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
         volumeMounts:
         - name: postgres-storage
           mountPath: /var/lib/postgresql/data
-          subPath: postgres
+          # Note: subPath removed to allow fsGroup to work correctly
         - name: init-script
           mountPath: /docker-entrypoint-initdb.d
         - name: tmp


### PR DESCRIPTION
…ionner

Problème persistant après la première correction :
- PostgreSQL affichait toujours "Operation not permitted"
- Le retrait de readOnlyRootFilesystem n'était pas suffisant

Cause racine #2 identifiée :
- Utilisation de "subPath: postgres" dans le volumeMount
- subPath empêche fsGroup d'appliquer les permissions correctement
- Problème connu de Kubernetes depuis la v1.9

Solution appliquée :
1. Retiré "subPath: postgres" du volumeMount
2. Ajouté variable d'environnement PGDATA=/var/lib/postgresql/data/pgdata
   - PostgreSQL nécessite PGDATA vers un sous-répertoire vide
   - Permet à initdb de vérifier et initialiser correctement
3. Le fsGroup: 70 s'applique maintenant correctement au volume entier

Explication technique :
- Sans subPath, le PVC est monté directement sur /var/lib/postgresql/data
- fsGroup: 70 change le propriétaire de tout le volume (chown -R 70:70)
- PGDATA pointe vers /var/lib/postgresql/data/pgdata (sous-répertoire)
- PostgreSQL crée ce sous-répertoire avec les permissions correctes

Fichiers modifiés :
- tp10/04-postgres-deployment.yaml :
  * Retiré subPath: postgres (ligne 79 → 83)
  * Ajouté env PGDATA (lignes 76-79)
- .claude/CONTEXT.md : Documentation de la correction #2
- .claude/SECURITY.md :
  * Ajout commentaires sur PGDATA et subPath
  * Nouvelle section "❌ 0. Utiliser subPath avec des bases de données"

Documentation :
https://github.com/kubernetes/kubernetes/issues/52093 https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath

Ref: Session 2025-12-17 (correction #2)