### PR TITLE
Fix backend API URL for client-side access

### DIFF
--- a/tp10/12-frontend-config.yaml
+++ b/tp10/12-frontend-config.yaml
@@ -163,7 +163,8 @@ data:
         </div>
 
         <script>
-            const API_URL = 'http://backend-api:5000';
+            // Utiliser une URL relative car Nginx proxie /api vers le backend
+            const API_URL = '/api';
 
             async function loadTasks(priority = null) {
                 const tasksList = document.getElementById('tasksList');

--- a/tp10/12-frontend-nginx-config.yaml
+++ b/tp10/12-frontend-nginx-config.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-nginx-config
+  namespace: taskflow
+  labels:
+    app: frontend
+data:
+  nginx.conf: |
+    # Configuration Nginx optimisée pour Alpine avec reverse proxy vers backend API
+
+    # Utilisateur nginx (UID 101 pour nginx:alpine)
+    user nginx;
+
+    # Nombre de workers (auto = nombre de CPU)
+    worker_processes auto;
+
+    # Fichier PID (dans /var/run qui est un emptyDir)
+    pid /var/run/nginx.pid;
+
+    # Gestion des événements
+    events {
+        worker_connections 1024;
+    }
+
+    # Configuration HTTP
+    http {
+        # Types MIME
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+
+        # Logging (vers stdout/stderr pour Kubernetes)
+        access_log /dev/stdout;
+        error_log /dev/stderr warn;
+
+        # Performance
+        sendfile on;
+        tcp_nopush on;
+        tcp_nodelay on;
+        keepalive_timeout 65;
+        types_hash_max_size 2048;
+
+        # Gzip compression
+        gzip on;
+        gzip_vary on;
+        gzip_min_length 1000;
+        gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript;
+
+        # Serveur principal
+        server {
+            listen 80;
+            server_name _;
+
+            # Root directory (ConfigMap monté)
+            root /usr/share/nginx/html;
+            index index.html;
+
+            # Frontend - Servir l'application HTML/JS
+            location / {
+                try_files $uri $uri/ /index.html;
+
+                # Headers de sécurité
+                add_header X-Content-Type-Options "nosniff" always;
+                add_header X-Frame-Options "SAMEORIGIN" always;
+                add_header X-XSS-Protection "1; mode=block" always;
+            }
+
+            # API Backend - Reverse proxy vers le service backend-api
+            location /api/ {
+                # Supprimer le préfixe /api avant de transférer
+                rewrite ^/api/(.*) /$1 break;
+
+                # Proxy vers le service Kubernetes backend-api
+                proxy_pass http://backend-api:5000;
+
+                # Headers de proxy standards
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                # Timeouts
+                proxy_connect_timeout 30s;
+                proxy_send_timeout 30s;
+                proxy_read_timeout 30s;
+
+                # Buffers
+                proxy_buffering on;
+                proxy_buffer_size 4k;
+                proxy_buffers 8 4k;
+                proxy_busy_buffers_size 8k;
+            }
+
+            # Health check endpoint
+            location /health {
+                access_log off;
+                return 200 "healthy\n";
+                add_header Content-Type text/plain;
+            }
+        }
+    }

--- a/tp10/13-frontend-deployment.yaml
+++ b/tp10/13-frontend-deployment.yaml
@@ -41,6 +41,9 @@ spec:
         volumeMounts:
         - name: html
           mountPath: /usr/share/nginx/html
+        - name: nginx-config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
         - name: cache
           mountPath: /var/cache/nginx
         - name: run
@@ -59,6 +62,9 @@ spec:
       - name: html
         configMap:
           name: frontend-html
+      - name: nginx-config
+        configMap:
+          name: frontend-nginx-config
       - name: cache
         emptyDir: {}
       - name: run

--- a/tp10/deploy.sh
+++ b/tp10/deploy.sh
@@ -70,6 +70,7 @@ echo ""
 
 # Déployer Frontend
 echo -e "${YELLOW}[5/8] Déploiement du Frontend${NC}"
+kubectl apply -f 12-frontend-nginx-config.yaml
 kubectl apply -f 12-frontend-config.yaml
 kubectl apply -f 13-frontend-deployment.yaml
 kubectl apply -f 14-frontend-service.yaml


### PR DESCRIPTION
…everse proxy Nginx

Problème identifié :
- Le frontend (HTML/JS) utilisait http://backend-api:5000 dans le navigateur client
- Cette URL interne Kubernetes n'est pas accessible depuis le navigateur
- Le DNS .svc.cluster.local et les IPs internes ne sont pas routables côté client

Solution appliquée :
- Création de 12-frontend-nginx-config.yaml avec configuration reverse proxy
- Nginx proxie /api/* vers http://backend-api:5000/*
- Modification de l'URL dans le frontend : http://backend-api:5000 → /api
- Mise à jour du deployment frontend pour monter la config Nginx personnalisée

Architecture finale :
Navigateur → /api → Nginx (reverse proxy) → http://backend-api:5000

Fichiers modifiés :
- tp10/12-frontend-nginx-config.yaml (nouveau) : Configuration Nginx avec reverse proxy
- tp10/12-frontend-config.yaml : URL API changée de http://backend-api:5000 à /api
- tp10/13-frontend-deployment.yaml : Ajout du volume nginx-config
- tp10/deploy.sh : Ajout de l'application du nouveau ConfigMap
- tp10/README.md : Documentation complète de l'architecture et du reverse proxy

Note : Le load generator (22-load-generator.yaml) conserve l'URL interne car il s'exécute dans le cluster et peut accéder directement aux services internes.