### PR TITLE
Fix test script returning early after first test

### DIFF
--- a/tp10/test-tp10.sh
+++ b/tp10/test-tp10.sh
@@ -3,7 +3,8 @@
 # Script de test pour le TP10 - Projet de Synthèse TaskFlow
 # Teste le déploiement complet, l'autoscaling et le monitoring
 
-set -e
+# Note: set -e est intentionnellement désactivé car le script a sa propre logique
+# de gestion des erreurs avec les compteurs FAILED_TESTS et PASSED_TESTS
 
 # Couleurs pour l'affichage
 RED='\033[0;31m'


### PR DESCRIPTION
- Retirer 'set -e' qui causait l'arrêt après le premier échec
- Le script a sa propre gestion d'erreurs avec FAILED_TESTS/PASSED_TESTS
- Ajouter commentaire explicatif sur la raison de ce choix