### PR TITLE
Update deploy script with Grafana datasources

### DIFF
--- a/tp10/deploy.sh
+++ b/tp10/deploy.sh
@@ -90,6 +90,7 @@ echo ""
 
 # Déployer Grafana
 echo -e "${YELLOW}[7/8] Déploiement de Grafana${NC}"
+kubectl apply -f 20-grafana-datasource.yaml
 kubectl apply -f 20-grafana-deployment.yaml
 kubectl apply -f 21-grafana-service.yaml
 kubectl wait --for=condition=ready pod -l app=grafana -n $NAMESPACE --timeout=120s

--- a/tp10/test-metrics-flow.sh
+++ b/tp10/test-metrics-flow.sh
@@ -131,7 +131,7 @@ kubectl exec -n $NAMESPACE $GRAFANA_POD -- cat /etc/grafana/provisioning/datasou
 
 # Interroger l'API Grafana pour lister les datasources
 echo "   Vérification via l'API Grafana..."
-DATASOURCES=$(kubectl exec -n $NAMESPACE $GRAFANA_POD -- wget -q -O - --header="Content-Type: application/json" --user=admin --password=admin2024 http://localhost:3000/api/datasources 2>/dev/null || echo "")
+DATASOURCES=$(kubectl exec -n $NAMESPACE $GRAFANA_POD -- curl -s -u admin:admin2024 http://localhost:3000/api/datasources 2>/dev/null || echo "")
 if [ -z "$DATASOURCES" ]; then
     fail "Impossible d'interroger l'API Grafana pour lister les datasources"
 fi
@@ -162,7 +162,7 @@ fi
 pass "Datasource ID: $DATASOURCE_ID"
 
 # Tester la datasource
-TEST_RESULT=$(kubectl exec -n $NAMESPACE $GRAFANA_POD -- wget -q -O - --header="Content-Type: application/json" --user=admin --password=admin2024 http://localhost:3000/api/datasources/$DATASOURCE_ID 2>/dev/null || echo "")
+TEST_RESULT=$(kubectl exec -n $NAMESPACE $GRAFANA_POD -- curl -s -u admin:admin2024 http://localhost:3000/api/datasources/$DATASOURCE_ID 2>/dev/null || echo "")
 
 if echo "$TEST_RESULT" | grep -q '"type":"prometheus"'; then
     pass "La datasource Prometheus est bien configurée"
@@ -176,7 +176,7 @@ echo "--------------------------------------------"
 
 # Effectuer une requête Prometheus via l'API Grafana
 echo "   Exécution d'une requête test: up{job=\"kubernetes-pods\"}..."
-QUERY_RESULT=$(kubectl exec -n $NAMESPACE $GRAFANA_POD -- wget -q -O - --header="Content-Type: application/json" --user=admin --password=admin2024 "http://localhost:3000/api/datasources/proxy/$DATASOURCE_ID/api/v1/query?query=up" 2>/dev/null || echo "")
+QUERY_RESULT=$(kubectl exec -n $NAMESPACE $GRAFANA_POD -- curl -s -u admin:admin2024 "http://localhost:3000/api/datasources/proxy/$DATASOURCE_ID/api/v1/query?query=up" 2>/dev/null || echo "")
 
 if [ -z "$QUERY_RESULT" ]; then
     fail "Impossible d'exécuter une requête via Grafana"


### PR DESCRIPTION
Problèmes corrigés :

1. **deploy.sh** : Ajout du déploiement manquant de 20-grafana-datasource.yaml
   - La ConfigMap grafana-datasources n'était pas déployée par le script
   - Ajout de `kubectl apply -f 20-grafana-datasource.yaml` avant le deployment

2. **test-metrics-flow.sh** : Correction de l'authentification API Grafana
   - Remplacement de `wget --user/--password` par `curl -u` (3 occurrences)
   - Les options `--user/--password` de wget sont pour FTP, pas HTTP Basic Auth
   - `curl -u admin:admin2024` utilise correctement HTTP Basic Auth
   - Correction aux lignes 134, 165, et 179

Résultat attendu :
- Le script deploy.sh déploie maintenant tous les composants nécessaires
- Le test test-metrics-flow.sh peut maintenant interroger l'API Grafana
- La datasource Prometheus est correctement provisionnée dans Grafana