### PR TITLE
feat(tp10): Ajouter dashboard Grafana pré-configuré pour TaskFlow

### DIFF
--- a/tp10/20-grafana-deployment.yaml
+++ b/tp10/20-grafana-deployment.yaml
@@ -68,6 +68,12 @@ spec:
         - name: grafana-datasources
           mountPath: /etc/grafana/provisioning/datasources
           readOnly: true
+        - name: grafana-dashboard-provider
+          mountPath: /etc/grafana/provisioning/dashboards
+          readOnly: true
+        - name: grafana-dashboards
+          mountPath: /var/lib/grafana/dashboards
+          readOnly: true
 
       volumes:
       - name: grafana-storage
@@ -79,3 +85,9 @@ spec:
       - name: grafana-datasources
         configMap:
           name: grafana-datasources
+      - name: grafana-dashboard-provider
+        configMap:
+          name: grafana-dashboard-provider
+      - name: grafana-dashboards
+        configMap:
+          name: grafana-dashboards

--- a/tp10/23-grafana-dashboard-taskflow.json
+++ b/tp10/23-grafana-dashboard-taskflow.json
@@ -1,0 +1,521 @@
+{
+  "dashboard": {
+    "id": null,
+    "uid": "taskflow-overview",
+    "title": "TaskFlow - Overview & Auto-scaling",
+    "tags": ["kubernetes", "taskflow", "autoscaling"],
+    "timezone": "browser",
+    "schemaVersion": 27,
+    "version": 1,
+    "refresh": "10s",
+    "time": {
+      "from": "now-15m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": ["5s", "10s", "30s", "1m", "5m"]
+    },
+    "annotations": {
+      "list": []
+    },
+    "panels": [
+      {
+        "id": 1,
+        "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+        "type": "row",
+        "title": "📊 Vue d'ensemble - État de l'application"
+      },
+      {
+        "id": 2,
+        "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+        "type": "stat",
+        "title": "Pods Running",
+        "targets": [
+          {
+            "expr": "count(up{job=\"kubernetes-pods\", namespace=\"taskflow\"} == 1)",
+            "refId": "A"
+          }
+        ],
+        "options": {
+          "graphMode": "none",
+          "colorMode": "background",
+          "justifyMode": "center",
+          "textMode": "value_and_name"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {"value": 0, "color": "red"},
+                {"value": 3, "color": "yellow"},
+                {"value": 5, "color": "green"}
+              ]
+            },
+            "unit": "short"
+          }
+        }
+      },
+      {
+        "id": 3,
+        "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+        "type": "stat",
+        "title": "Backend Pods (HPA)",
+        "targets": [
+          {
+            "expr": "count(up{job=\"kubernetes-pods\", namespace=\"taskflow\", app=\"backend-api\"} == 1)",
+            "refId": "A"
+          }
+        ],
+        "options": {
+          "graphMode": "area",
+          "colorMode": "background",
+          "justifyMode": "center"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {"value": 0, "color": "red"},
+                {"value": 2, "color": "green"},
+                {"value": 8, "color": "yellow"},
+                {"value": 10, "color": "red"}
+              ]
+            },
+            "unit": "short",
+            "min": 0,
+            "max": 10
+          }
+        },
+        "description": "Nombre de pods backend-api actifs (min=2, max=10)"
+      },
+      {
+        "id": 4,
+        "gridPos": {"h": 4, "w": 6, "x": 12, "y": 1},
+        "type": "stat",
+        "title": "PostgreSQL",
+        "targets": [
+          {
+            "expr": "up{job=\"kubernetes-pods\", namespace=\"taskflow\", app=\"postgres\"}",
+            "refId": "A"
+          }
+        ],
+        "options": {
+          "graphMode": "none",
+          "colorMode": "background"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {"value": 0, "color": "red"},
+                {"value": 1, "color": "green"}
+              ]
+            },
+            "mappings": [
+              {"type": "value", "value": "0", "text": "DOWN"},
+              {"type": "value", "value": "1", "text": "UP"}
+            ]
+          }
+        }
+      },
+      {
+        "id": 5,
+        "gridPos": {"h": 4, "w": 6, "x": 18, "y": 1},
+        "type": "stat",
+        "title": "Redis Cache",
+        "targets": [
+          {
+            "expr": "up{job=\"kubernetes-pods\", namespace=\"taskflow\", app=\"redis\"}",
+            "refId": "A"
+          }
+        ],
+        "options": {
+          "graphMode": "none",
+          "colorMode": "background"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {"value": 0, "color": "red"},
+                {"value": 1, "color": "green"}
+              ]
+            },
+            "mappings": [
+              {"type": "value", "value": "0", "text": "DOWN"},
+              {"type": "value", "value": "1", "text": "UP"}
+            ]
+          }
+        }
+      },
+      {
+        "id": 10,
+        "gridPos": {"h": 1, "w": 24, "x": 0, "y": 5},
+        "type": "row",
+        "title": "🚀 Auto-scaling Backend API"
+      },
+      {
+        "id": 11,
+        "gridPos": {"h": 8, "w": 8, "x": 0, "y": 6},
+        "type": "graph",
+        "title": "Nombre de Pods Backend (évolution)",
+        "targets": [
+          {
+            "expr": "count(up{job=\"kubernetes-pods\", namespace=\"taskflow\", app=\"backend-api\"} == 1)",
+            "refId": "A",
+            "legendFormat": "Backend Pods"
+          }
+        ],
+        "yaxes": [
+          {"format": "short", "min": 0, "max": 12},
+          {"format": "short"}
+        ],
+        "lines": true,
+        "fill": 2,
+        "linewidth": 2,
+        "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true, "min": true},
+        "tooltip": {"shared": true}
+      },
+      {
+        "id": 12,
+        "gridPos": {"h": 8, "w": 8, "x": 8, "y": 6},
+        "type": "graph",
+        "title": "CPU Usage - Backend Pods",
+        "targets": [
+          {
+            "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"backend-api.*\"}[1m])) * 100",
+            "refId": "A",
+            "legendFormat": "Total CPU %"
+          },
+          {
+            "expr": "avg(rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"backend-api.*\"}[1m])) * 100",
+            "refId": "B",
+            "legendFormat": "Avg CPU % per pod"
+          }
+        ],
+        "yaxes": [
+          {"format": "percent", "min": 0},
+          {"format": "short"}
+        ],
+        "lines": true,
+        "fill": 2,
+        "linewidth": 2,
+        "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true},
+        "tooltip": {"shared": true},
+        "thresholds": [
+          {"value": 50, "colorMode": "custom", "op": "gt", "fill": true, "line": true, "fillColor": "rgba(255, 255, 0, 0.2)", "lineColor": "rgb(255, 255, 0)"}
+        ]
+      },
+      {
+        "id": 13,
+        "gridPos": {"h": 8, "w": 8, "x": 16, "y": 6},
+        "type": "graph",
+        "title": "Memory Usage - Backend Pods",
+        "targets": [
+          {
+            "expr": "sum(container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"backend-api.*\"}) / 1024 / 1024",
+            "refId": "A",
+            "legendFormat": "Total Memory (MB)"
+          },
+          {
+            "expr": "avg(container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"backend-api.*\"}) / 1024 / 1024",
+            "refId": "B",
+            "legendFormat": "Avg Memory (MB) per pod"
+          }
+        ],
+        "yaxes": [
+          {"format": "mbytes", "min": 0},
+          {"format": "short"}
+        ],
+        "lines": true,
+        "fill": 2,
+        "linewidth": 2,
+        "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true},
+        "tooltip": {"shared": true},
+        "thresholds": [
+          {"value": 180, "colorMode": "custom", "op": "gt", "fill": true, "line": true, "fillColor": "rgba(255, 255, 0, 0.2)", "lineColor": "rgb(255, 255, 0)"}
+        ]
+      },
+      {
+        "id": 20,
+        "gridPos": {"h": 1, "w": 24, "x": 0, "y": 14},
+        "type": "row",
+        "title": "💻 Métriques CPU - Tous les composants"
+      },
+      {
+        "id": 21,
+        "gridPos": {"h": 8, "w": 24, "x": 0, "y": 15},
+        "type": "graph",
+        "title": "CPU Usage par Pod",
+        "targets": [
+          {
+            "expr": "rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"backend-api.*\", container!=\"POD\", container!=\"\"}[1m]) * 100",
+            "refId": "A",
+            "legendFormat": "{{pod}}"
+          },
+          {
+            "expr": "rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"postgres.*\", container!=\"POD\", container!=\"\"}[1m]) * 100",
+            "refId": "B",
+            "legendFormat": "{{pod}}"
+          },
+          {
+            "expr": "rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"redis.*\", container!=\"POD\", container!=\"\"}[1m]) * 100",
+            "refId": "C",
+            "legendFormat": "{{pod}}"
+          }
+        ],
+        "yaxes": [
+          {"format": "percent", "min": 0},
+          {"format": "short"}
+        ],
+        "lines": true,
+        "fill": 1,
+        "linewidth": 2,
+        "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true, "values": true},
+        "tooltip": {"shared": true, "sort": 2}
+      },
+      {
+        "id": 30,
+        "gridPos": {"h": 1, "w": 24, "x": 0, "y": 23},
+        "type": "row",
+        "title": "🧠 Métriques Mémoire - Tous les composants"
+      },
+      {
+        "id": 31,
+        "gridPos": {"h": 8, "w": 24, "x": 0, "y": 24},
+        "type": "graph",
+        "title": "Memory Usage par Pod",
+        "targets": [
+          {
+            "expr": "container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"backend-api.*\", container!=\"POD\", container!=\"\"} / 1024 / 1024",
+            "refId": "A",
+            "legendFormat": "{{pod}}"
+          },
+          {
+            "expr": "container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"postgres.*\", container!=\"POD\", container!=\"\"} / 1024 / 1024",
+            "refId": "B",
+            "legendFormat": "{{pod}}"
+          },
+          {
+            "expr": "container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"redis.*\", container!=\"POD\", container!=\"\"} / 1024 / 1024",
+            "refId": "C",
+            "legendFormat": "{{pod}}"
+          }
+        ],
+        "yaxes": [
+          {"format": "mbytes", "min": 0},
+          {"format": "short"}
+        ],
+        "lines": true,
+        "fill": 1,
+        "linewidth": 2,
+        "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true, "values": true},
+        "tooltip": {"shared": true, "sort": 2}
+      },
+      {
+        "id": 40,
+        "gridPos": {"h": 1, "w": 24, "x": 0, "y": 32},
+        "type": "row",
+        "title": "🗄️ Base de données PostgreSQL"
+      },
+      {
+        "id": 41,
+        "gridPos": {"h": 6, "w": 12, "x": 0, "y": 33},
+        "type": "graph",
+        "title": "PostgreSQL - CPU & Memory",
+        "targets": [
+          {
+            "expr": "rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"postgres.*\", container=\"postgres\"}[1m]) * 100",
+            "refId": "A",
+            "legendFormat": "CPU %"
+          },
+          {
+            "expr": "container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"postgres.*\", container=\"postgres\"} / 1024 / 1024",
+            "refId": "B",
+            "legendFormat": "Memory (MB)"
+          }
+        ],
+        "yaxes": [
+          {"format": "short", "min": 0},
+          {"format": "short"}
+        ],
+        "lines": true,
+        "fill": 2,
+        "linewidth": 2,
+        "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true},
+        "tooltip": {"shared": true}
+      },
+      {
+        "id": 42,
+        "gridPos": {"h": 6, "w": 12, "x": 12, "y": 33},
+        "type": "stat",
+        "title": "PostgreSQL - État",
+        "targets": [
+          {
+            "expr": "up{job=\"kubernetes-pods\", namespace=\"taskflow\", app=\"postgres\"}",
+            "refId": "A"
+          }
+        ],
+        "options": {
+          "graphMode": "area",
+          "colorMode": "background"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {"value": 0, "color": "red"},
+                {"value": 1, "color": "green"}
+              ]
+            },
+            "mappings": [
+              {"type": "value", "value": "0", "text": "DOWN ❌"},
+              {"type": "value", "value": "1", "text": "UP ✅"}
+            ]
+          }
+        },
+        "description": "État de la base de données PostgreSQL"
+      },
+      {
+        "id": 50,
+        "gridPos": {"h": 1, "w": 24, "x": 0, "y": 39},
+        "type": "row",
+        "title": "⚡ Cache Redis"
+      },
+      {
+        "id": 51,
+        "gridPos": {"h": 6, "w": 12, "x": 0, "y": 40},
+        "type": "graph",
+        "title": "Redis - CPU & Memory",
+        "targets": [
+          {
+            "expr": "rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"redis.*\", container=\"redis\"}[1m]) * 100",
+            "refId": "A",
+            "legendFormat": "CPU %"
+          },
+          {
+            "expr": "container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"redis.*\", container=\"redis\"} / 1024 / 1024",
+            "refId": "B",
+            "legendFormat": "Memory (MB)"
+          }
+        ],
+        "yaxes": [
+          {"format": "short", "min": 0},
+          {"format": "short"}
+        ],
+        "lines": true,
+        "fill": 2,
+        "linewidth": 2,
+        "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true},
+        "tooltip": {"shared": true}
+      },
+      {
+        "id": 52,
+        "gridPos": {"h": 6, "w": 12, "x": 12, "y": 40},
+        "type": "stat",
+        "title": "Redis - État",
+        "targets": [
+          {
+            "expr": "up{job=\"kubernetes-pods\", namespace=\"taskflow\", app=\"redis\"}",
+            "refId": "A"
+          }
+        ],
+        "options": {
+          "graphMode": "area",
+          "colorMode": "background"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {"value": 0, "color": "red"},
+                {"value": 1, "color": "green"}
+              ]
+            },
+            "mappings": [
+              {"type": "value", "value": "0", "text": "DOWN ❌"},
+              {"type": "value", "value": "1", "text": "UP ✅"}
+            ]
+          }
+        },
+        "description": "État du cache Redis"
+      },
+      {
+        "id": 60,
+        "gridPos": {"h": 1, "w": 24, "x": 0, "y": 46},
+        "type": "row",
+        "title": "📡 Métriques Réseau"
+      },
+      {
+        "id": 61,
+        "gridPos": {"h": 6, "w": 12, "x": 0, "y": 47},
+        "type": "graph",
+        "title": "Network Received (Ingress)",
+        "targets": [
+          {
+            "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"taskflow\", pod=~\"backend-api.*\"}[1m])) / 1024",
+            "refId": "A",
+            "legendFormat": "Backend API"
+          },
+          {
+            "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"taskflow\", pod=~\"postgres.*\"}[1m])) / 1024",
+            "refId": "B",
+            "legendFormat": "PostgreSQL"
+          },
+          {
+            "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"taskflow\", pod=~\"redis.*\"}[1m])) / 1024",
+            "refId": "C",
+            "legendFormat": "Redis"
+          }
+        ],
+        "yaxes": [
+          {"format": "KBs", "min": 0},
+          {"format": "short"}
+        ],
+        "lines": true,
+        "fill": 1,
+        "linewidth": 2,
+        "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true},
+        "tooltip": {"shared": true}
+      },
+      {
+        "id": 62,
+        "gridPos": {"h": 6, "w": 12, "x": 12, "y": 47},
+        "type": "graph",
+        "title": "Network Transmitted (Egress)",
+        "targets": [
+          {
+            "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"taskflow\", pod=~\"backend-api.*\"}[1m])) / 1024",
+            "refId": "A",
+            "legendFormat": "Backend API"
+          },
+          {
+            "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"taskflow\", pod=~\"postgres.*\"}[1m])) / 1024",
+            "refId": "B",
+            "legendFormat": "PostgreSQL"
+          },
+          {
+            "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"taskflow\", pod=~\"redis.*\"}[1m])) / 1024",
+            "refId": "C",
+            "legendFormat": "Redis"
+          }
+        ],
+        "yaxes": [
+          {"format": "KBs", "min": 0},
+          {"format": "short"}
+        ],
+        "lines": true,
+        "fill": 1,
+        "linewidth": 2,
+        "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true},
+        "tooltip": {"shared": true}
+      }
+    ]
+  }
+}

--- a/tp10/24-grafana-dashboard-configmap.yaml
+++ b/tp10/24-grafana-dashboard-configmap.yaml
@@ -1,0 +1,531 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+  namespace: taskflow
+  labels:
+    app: grafana
+    component: dashboards
+data:
+  taskflow-overview.json: |
+    {
+      "dashboard": {
+        "id": null,
+        "uid": "taskflow-overview",
+        "title": "TaskFlow - Overview & Auto-scaling",
+        "tags": ["kubernetes", "taskflow", "autoscaling"],
+        "timezone": "browser",
+        "schemaVersion": 27,
+        "version": 1,
+        "refresh": "10s",
+        "time": {
+          "from": "now-15m",
+          "to": "now"
+        },
+        "timepicker": {
+          "refresh_intervals": ["5s", "10s", "30s", "1m", "5m"]
+        },
+        "annotations": {
+          "list": []
+        },
+        "panels": [
+          {
+            "id": 1,
+            "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+            "type": "row",
+            "title": "📊 Vue d'ensemble - État de l'application"
+          },
+          {
+            "id": 2,
+            "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+            "type": "stat",
+            "title": "Pods Running",
+            "targets": [
+              {
+                "expr": "count(up{job=\"kubernetes-pods\", namespace=\"taskflow\"} == 1)",
+                "refId": "A"
+              }
+            ],
+            "options": {
+              "graphMode": "none",
+              "colorMode": "background",
+              "justifyMode": "center",
+              "textMode": "value_and_name"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {"value": 0, "color": "red"},
+                    {"value": 3, "color": "yellow"},
+                    {"value": 5, "color": "green"}
+                  ]
+                },
+                "unit": "short"
+              }
+            }
+          },
+          {
+            "id": 3,
+            "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+            "type": "stat",
+            "title": "Backend Pods (HPA)",
+            "targets": [
+              {
+                "expr": "count(up{job=\"kubernetes-pods\", namespace=\"taskflow\", app=\"backend-api\"} == 1)",
+                "refId": "A"
+              }
+            ],
+            "options": {
+              "graphMode": "area",
+              "colorMode": "background",
+              "justifyMode": "center"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {"value": 0, "color": "red"},
+                    {"value": 2, "color": "green"},
+                    {"value": 8, "color": "yellow"},
+                    {"value": 10, "color": "red"}
+                  ]
+                },
+                "unit": "short",
+                "min": 0,
+                "max": 10
+              }
+            },
+            "description": "Nombre de pods backend-api actifs (min=2, max=10)"
+          },
+          {
+            "id": 4,
+            "gridPos": {"h": 4, "w": 6, "x": 12, "y": 1},
+            "type": "stat",
+            "title": "PostgreSQL",
+            "targets": [
+              {
+                "expr": "up{job=\"kubernetes-pods\", namespace=\"taskflow\", app=\"postgres\"}",
+                "refId": "A"
+              }
+            ],
+            "options": {
+              "graphMode": "none",
+              "colorMode": "background"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {"value": 0, "color": "red"},
+                    {"value": 1, "color": "green"}
+                  ]
+                },
+                "mappings": [
+                  {"type": "value", "value": "0", "text": "DOWN"},
+                  {"type": "value", "value": "1", "text": "UP"}
+                ]
+              }
+            }
+          },
+          {
+            "id": 5,
+            "gridPos": {"h": 4, "w": 6, "x": 18, "y": 1},
+            "type": "stat",
+            "title": "Redis Cache",
+            "targets": [
+              {
+                "expr": "up{job=\"kubernetes-pods\", namespace=\"taskflow\", app=\"redis\"}",
+                "refId": "A"
+              }
+            ],
+            "options": {
+              "graphMode": "none",
+              "colorMode": "background"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {"value": 0, "color": "red"},
+                    {"value": 1, "color": "green"}
+                  ]
+                },
+                "mappings": [
+                  {"type": "value", "value": "0", "text": "DOWN"},
+                  {"type": "value", "value": "1", "text": "UP"}
+                ]
+              }
+            }
+          },
+          {
+            "id": 10,
+            "gridPos": {"h": 1, "w": 24, "x": 0, "y": 5},
+            "type": "row",
+            "title": "🚀 Auto-scaling Backend API"
+          },
+          {
+            "id": 11,
+            "gridPos": {"h": 8, "w": 8, "x": 0, "y": 6},
+            "type": "graph",
+            "title": "Nombre de Pods Backend (évolution)",
+            "targets": [
+              {
+                "expr": "count(up{job=\"kubernetes-pods\", namespace=\"taskflow\", app=\"backend-api\"} == 1)",
+                "refId": "A",
+                "legendFormat": "Backend Pods"
+              }
+            ],
+            "yaxes": [
+              {"format": "short", "min": 0, "max": 12},
+              {"format": "short"}
+            ],
+            "lines": true,
+            "fill": 2,
+            "linewidth": 2,
+            "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true, "min": true},
+            "tooltip": {"shared": true}
+          },
+          {
+            "id": 12,
+            "gridPos": {"h": 8, "w": 8, "x": 8, "y": 6},
+            "type": "graph",
+            "title": "CPU Usage - Backend Pods",
+            "targets": [
+              {
+                "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"backend-api.*\"}[1m])) * 100",
+                "refId": "A",
+                "legendFormat": "Total CPU %"
+              },
+              {
+                "expr": "avg(rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"backend-api.*\"}[1m])) * 100",
+                "refId": "B",
+                "legendFormat": "Avg CPU % per pod"
+              }
+            ],
+            "yaxes": [
+              {"format": "percent", "min": 0},
+              {"format": "short"}
+            ],
+            "lines": true,
+            "fill": 2,
+            "linewidth": 2,
+            "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true},
+            "tooltip": {"shared": true},
+            "thresholds": [
+              {"value": 50, "colorMode": "custom", "op": "gt", "fill": true, "line": true, "fillColor": "rgba(255, 255, 0, 0.2)", "lineColor": "rgb(255, 255, 0)"}
+            ]
+          },
+          {
+            "id": 13,
+            "gridPos": {"h": 8, "w": 8, "x": 16, "y": 6},
+            "type": "graph",
+            "title": "Memory Usage - Backend Pods",
+            "targets": [
+              {
+                "expr": "sum(container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"backend-api.*\"}) / 1024 / 1024",
+                "refId": "A",
+                "legendFormat": "Total Memory (MB)"
+              },
+              {
+                "expr": "avg(container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"backend-api.*\"}) / 1024 / 1024",
+                "refId": "B",
+                "legendFormat": "Avg Memory (MB) per pod"
+              }
+            ],
+            "yaxes": [
+              {"format": "mbytes", "min": 0},
+              {"format": "short"}
+            ],
+            "lines": true,
+            "fill": 2,
+            "linewidth": 2,
+            "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true},
+            "tooltip": {"shared": true},
+            "thresholds": [
+              {"value": 180, "colorMode": "custom", "op": "gt", "fill": true, "line": true, "fillColor": "rgba(255, 255, 0, 0.2)", "lineColor": "rgb(255, 255, 0)"}
+            ]
+          },
+          {
+            "id": 20,
+            "gridPos": {"h": 1, "w": 24, "x": 0, "y": 14},
+            "type": "row",
+            "title": "💻 Métriques CPU - Tous les composants"
+          },
+          {
+            "id": 21,
+            "gridPos": {"h": 8, "w": 24, "x": 0, "y": 15},
+            "type": "graph",
+            "title": "CPU Usage par Pod",
+            "targets": [
+              {
+                "expr": "rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"backend-api.*\", container!=\"POD\", container!=\"\"}[1m]) * 100",
+                "refId": "A",
+                "legendFormat": "{{pod}}"
+              },
+              {
+                "expr": "rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"postgres.*\", container!=\"POD\", container!=\"\"}[1m]) * 100",
+                "refId": "B",
+                "legendFormat": "{{pod}}"
+              },
+              {
+                "expr": "rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"redis.*\", container!=\"POD\", container!=\"\"}[1m]) * 100",
+                "refId": "C",
+                "legendFormat": "{{pod}}"
+              }
+            ],
+            "yaxes": [
+              {"format": "percent", "min": 0},
+              {"format": "short"}
+            ],
+            "lines": true,
+            "fill": 1,
+            "linewidth": 2,
+            "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true, "values": true},
+            "tooltip": {"shared": true, "sort": 2}
+          },
+          {
+            "id": 30,
+            "gridPos": {"h": 1, "w": 24, "x": 0, "y": 23},
+            "type": "row",
+            "title": "🧠 Métriques Mémoire - Tous les composants"
+          },
+          {
+            "id": 31,
+            "gridPos": {"h": 8, "w": 24, "x": 0, "y": 24},
+            "type": "graph",
+            "title": "Memory Usage par Pod",
+            "targets": [
+              {
+                "expr": "container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"backend-api.*\", container!=\"POD\", container!=\"\"} / 1024 / 1024",
+                "refId": "A",
+                "legendFormat": "{{pod}}"
+              },
+              {
+                "expr": "container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"postgres.*\", container!=\"POD\", container!=\"\"} / 1024 / 1024",
+                "refId": "B",
+                "legendFormat": "{{pod}}"
+              },
+              {
+                "expr": "container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"redis.*\", container!=\"POD\", container!=\"\"} / 1024 / 1024",
+                "refId": "C",
+                "legendFormat": "{{pod}}"
+              }
+            ],
+            "yaxes": [
+              {"format": "mbytes", "min": 0},
+              {"format": "short"}
+            ],
+            "lines": true,
+            "fill": 1,
+            "linewidth": 2,
+            "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true, "values": true},
+            "tooltip": {"shared": true, "sort": 2}
+          },
+          {
+            "id": 40,
+            "gridPos": {"h": 1, "w": 24, "x": 0, "y": 32},
+            "type": "row",
+            "title": "🗄️ Base de données PostgreSQL"
+          },
+          {
+            "id": 41,
+            "gridPos": {"h": 6, "w": 12, "x": 0, "y": 33},
+            "type": "graph",
+            "title": "PostgreSQL - CPU & Memory",
+            "targets": [
+              {
+                "expr": "rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"postgres.*\", container=\"postgres\"}[1m]) * 100",
+                "refId": "A",
+                "legendFormat": "CPU %"
+              },
+              {
+                "expr": "container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"postgres.*\", container=\"postgres\"} / 1024 / 1024",
+                "refId": "B",
+                "legendFormat": "Memory (MB)"
+              }
+            ],
+            "yaxes": [
+              {"format": "short", "min": 0},
+              {"format": "short"}
+            ],
+            "lines": true,
+            "fill": 2,
+            "linewidth": 2,
+            "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true},
+            "tooltip": {"shared": true}
+          },
+          {
+            "id": 42,
+            "gridPos": {"h": 6, "w": 12, "x": 12, "y": 33},
+            "type": "stat",
+            "title": "PostgreSQL - État",
+            "targets": [
+              {
+                "expr": "up{job=\"kubernetes-pods\", namespace=\"taskflow\", app=\"postgres\"}",
+                "refId": "A"
+              }
+            ],
+            "options": {
+              "graphMode": "area",
+              "colorMode": "background"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {"value": 0, "color": "red"},
+                    {"value": 1, "color": "green"}
+                  ]
+                },
+                "mappings": [
+                  {"type": "value", "value": "0", "text": "DOWN ❌"},
+                  {"type": "value", "value": "1", "text": "UP ✅"}
+                ]
+              }
+            },
+            "description": "État de la base de données PostgreSQL"
+          },
+          {
+            "id": 50,
+            "gridPos": {"h": 1, "w": 24, "x": 0, "y": 39},
+            "type": "row",
+            "title": "⚡ Cache Redis"
+          },
+          {
+            "id": 51,
+            "gridPos": {"h": 6, "w": 12, "x": 0, "y": 40},
+            "type": "graph",
+            "title": "Redis - CPU & Memory",
+            "targets": [
+              {
+                "expr": "rate(container_cpu_usage_seconds_total{namespace=\"taskflow\", pod=~\"redis.*\", container=\"redis\"}[1m]) * 100",
+                "refId": "A",
+                "legendFormat": "CPU %"
+              },
+              {
+                "expr": "container_memory_usage_bytes{namespace=\"taskflow\", pod=~\"redis.*\", container=\"redis\"} / 1024 / 1024",
+                "refId": "B",
+                "legendFormat": "Memory (MB)"
+              }
+            ],
+            "yaxes": [
+              {"format": "short", "min": 0},
+              {"format": "short"}
+            ],
+            "lines": true,
+            "fill": 2,
+            "linewidth": 2,
+            "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true},
+            "tooltip": {"shared": true}
+          },
+          {
+            "id": 52,
+            "gridPos": {"h": 6, "w": 12, "x": 12, "y": 40},
+            "type": "stat",
+            "title": "Redis - État",
+            "targets": [
+              {
+                "expr": "up{job=\"kubernetes-pods\", namespace=\"taskflow\", app=\"redis\"}",
+                "refId": "A"
+              }
+            ],
+            "options": {
+              "graphMode": "area",
+              "colorMode": "background"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {"value": 0, "color": "red"},
+                    {"value": 1, "color": "green"}
+                  ]
+                },
+                "mappings": [
+                  {"type": "value", "value": "0", "text": "DOWN ❌"},
+                  {"type": "value", "value": "1", "text": "UP ✅"}
+                ]
+              }
+            },
+            "description": "État du cache Redis"
+          },
+          {
+            "id": 60,
+            "gridPos": {"h": 1, "w": 24, "x": 0, "y": 46},
+            "type": "row",
+            "title": "📡 Métriques Réseau"
+          },
+          {
+            "id": 61,
+            "gridPos": {"h": 6, "w": 12, "x": 0, "y": 47},
+            "type": "graph",
+            "title": "Network Received (Ingress)",
+            "targets": [
+              {
+                "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"taskflow\", pod=~\"backend-api.*\"}[1m])) / 1024",
+                "refId": "A",
+                "legendFormat": "Backend API"
+              },
+              {
+                "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"taskflow\", pod=~\"postgres.*\"}[1m])) / 1024",
+                "refId": "B",
+                "legendFormat": "PostgreSQL"
+              },
+              {
+                "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"taskflow\", pod=~\"redis.*\"}[1m])) / 1024",
+                "refId": "C",
+                "legendFormat": "Redis"
+              }
+            ],
+            "yaxes": [
+              {"format": "KBs", "min": 0},
+              {"format": "short"}
+            ],
+            "lines": true,
+            "fill": 1,
+            "linewidth": 2,
+            "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true},
+            "tooltip": {"shared": true}
+          },
+          {
+            "id": 62,
+            "gridPos": {"h": 6, "w": 12, "x": 12, "y": 47},
+            "type": "graph",
+            "title": "Network Transmitted (Egress)",
+            "targets": [
+              {
+                "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"taskflow\", pod=~\"backend-api.*\"}[1m])) / 1024",
+                "refId": "A",
+                "legendFormat": "Backend API"
+              },
+              {
+                "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"taskflow\", pod=~\"postgres.*\"}[1m])) / 1024",
+                "refId": "B",
+                "legendFormat": "PostgreSQL"
+              },
+              {
+                "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"taskflow\", pod=~\"redis.*\"}[1m])) / 1024",
+                "refId": "C",
+                "legendFormat": "Redis"
+              }
+            ],
+            "yaxes": [
+              {"format": "KBs", "min": 0},
+              {"format": "short"}
+            ],
+            "lines": true,
+            "fill": 1,
+            "linewidth": 2,
+            "legend": {"show": true, "alignAsTable": true, "avg": true, "current": true, "max": true},
+            "tooltip": {"shared": true}
+          }
+        ]
+      }
+    }

--- a/tp10/25-grafana-dashboard-provider.yaml
+++ b/tp10/25-grafana-dashboard-provider.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provider
+  namespace: taskflow
+  labels:
+    app: grafana
+    component: dashboard-provider
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+    - name: 'TaskFlow Dashboards'
+      orgId: 1
+      folder: ''
+      type: file
+      disableDeletion: false
+      editable: true
+      updateIntervalSeconds: 10
+      allowUiUpdates: true
+      options:
+        path: /var/lib/grafana/dashboards

--- a/tp10/README.md
+++ b/tp10/README.md
@@ -1730,15 +1730,22 @@ minikube service grafana -n taskflow
      - Status: ✅ **"Data source is working"**
    - ℹ️ La datasource est provisionée automatiquement au démarrage de Grafana
 
-4. Créer un dashboard :
-   - Aller dans **Dashboards** → **New** → **New Dashboard**
-   - Ajouter des panels pour :
-     - CPU usage des pods backend
-     - Memory usage des pods backend
-     - Nombre de replicas du deployment backend-api
-     - Requêtes par seconde
+4. **Accéder au dashboard pré-configuré (déjà disponible)** :
+   - Aller dans **Dashboards** → **Browse**
+   - Cliquer sur **"TaskFlow - Overview & Auto-scaling"**
+   - 🎉 **Le dashboard est déjà configuré avec toutes les métriques importantes !**
 
-**Requêtes PromQL utiles** :
+**Contenu du dashboard pré-configuré** :
+- 📊 **Vue d'ensemble** : État des pods (Running, Backend Pods HPA, PostgreSQL, Redis)
+- 🚀 **Auto-scaling Backend API** : Évolution du nombre de pods, CPU, mémoire
+- 💻 **Métriques CPU** : Usage CPU détaillé par pod (backend, postgres, redis)
+- 🧠 **Métriques Mémoire** : Usage mémoire détaillé par pod
+- 🗄️ **Base de données PostgreSQL** : État et ressources
+- ⚡ **Cache Redis** : État et ressources
+- 📡 **Métriques Réseau** : Trafic entrant/sortant
+
+**Personnalisation (optionnel)** :
+Si vous souhaitez créer vos propres dashboards ou panels :
 ```promql
 # Pods actifs
 up{job="kubernetes-pods"}
@@ -1749,8 +1756,8 @@ rate(container_cpu_usage_seconds_total[5m])
 # Utilisation mémoire
 container_memory_usage_bytes
 
-# Nombre de replicas
-kube_deployment_status_replicas{deployment="backend-api"}
+# Nombre de replicas backend
+count(up{job="kubernetes-pods", app="backend-api"} == 1)
 ```
 
 ### 8.5 Observer le HPA (avant charge)
@@ -1830,11 +1837,27 @@ kubectl delete job load-generator -n taskflow
 
 ### 9.4 Observer dans Grafana
 
-Pendant le test, observer dans Grafana :
-1. Le **CPU usage** monter puis se stabiliser
-2. Le **nombre de pods** augmenter de 2 à 8-10
-3. Les **requêtes par seconde** augmenter
-4. La **latence** rester stable grâce à l'autoscaling
+Ouvrir le **dashboard pré-configuré "TaskFlow - Overview & Auto-scaling"** dans Grafana.
+
+Pendant le test, observer en temps réel :
+
+**Section "Auto-scaling Backend API"** :
+1. 📈 **Nombre de Pods Backend (évolution)** : Passe de 2 à 8-10 pods
+2. 🔥 **CPU Usage - Backend Pods** : Monte rapidement vers 50% (seuil HPA)
+3. 🧠 **Memory Usage - Backend Pods** : Augmente progressivement
+
+**Section "Vue d'ensemble"** :
+- Le **Backend Pods (HPA)** panel change de couleur (vert → jaune → rouge selon le nombre)
+- Les métriques sont rafraîchies toutes les 10 secondes
+
+**Section "Métriques CPU/Mémoire"** :
+- Voir tous les pods individuellement avec leur consommation
+- Observer l'ajout de nouveaux pods en temps réel
+
+**Timeline attendue** :
+- **0-2 min** : CPU monte rapidement, premiers pods créés
+- **2-5 min** : Stabilisation autour de 8-10 pods
+- **Après arrêt du load generator** : Scale-down progressif vers 2 pods (5-10 min)
 
 ## 📊 Partie 10 : Analyse et Nettoyage
 

--- a/tp10/deploy.sh
+++ b/tp10/deploy.sh
@@ -91,6 +91,8 @@ echo ""
 # Déployer Grafana
 echo -e "${YELLOW}[7/8] Déploiement de Grafana${NC}"
 kubectl apply -f 20-grafana-datasource.yaml
+kubectl apply -f 24-grafana-dashboard-configmap.yaml
+kubectl apply -f 25-grafana-dashboard-provider.yaml
 kubectl apply -f 20-grafana-deployment.yaml
 kubectl apply -f 21-grafana-service.yaml
 kubectl wait --for=condition=ready pod -l app=grafana -n $NAMESPACE --timeout=120s


### PR DESCRIPTION
Ajout d'un dashboard Grafana complet avec provisioning automatique pour visualiser toutes les métriques importantes du TP10.

**Nouveaux fichiers** :
- 23-grafana-dashboard-taskflow.json : Modèle JSON du dashboard (backup)
- 24-grafana-dashboard-configmap.yaml : ConfigMap contenant le dashboard JSON
- 25-grafana-dashboard-provider.yaml : Configuration du provisioning

**Fichiers modifiés** :
- 20-grafana-deployment.yaml : Ajout des volumeMounts pour les dashboards
- deploy.sh : Déploiement des nouvelles ConfigMaps
- README.md : Documentation du dashboard pré-configuré

**Contenu du dashboard** :
- 📊 Vue d'ensemble : État des pods (Running, Backend Pods HPA, PostgreSQL, Redis)
- 🚀 Auto-scaling Backend API : Évolution du nombre de pods, CPU, mémoire
- 💻 Métriques CPU : Usage détaillé par pod
- 🧠 Métriques Mémoire : Usage détaillé par pod
- 🗄️ PostgreSQL : État et ressources
- ⚡ Redis : État et ressources
- 📡 Métriques Réseau : Trafic entrant/sortant

**Bénéfices pédagogiques** :
- Les étudiants ont immédiatement accès à toutes les métriques pertinentes
- Observation en temps réel de l'auto-scaling (rafraîchissement 10s)
- Panneaux pré-configurés avec requêtes PromQL optimisées
- Dashboard disponible automatiquement après déploiement

**Accès au dashboard** :
- Ouvrir Grafana → Dashboards → Browse
- Sélectionner "TaskFlow - Overview & Auto-scaling"