### PR TITLE
Fix missing preloaded taskflow dashboards

### DIFF
--- a/tp10/23-grafana-dashboard-taskflow.json
+++ b/tp10/23-grafana-dashboard-taskflow.json
@@ -1,23 +1,22 @@
 {
-  "dashboard": {
-    "id": null,
-    "uid": "taskflow-overview",
-    "title": "TaskFlow - Overview & Auto-scaling",
-    "tags": ["kubernetes", "taskflow", "autoscaling"],
-    "timezone": "browser",
-    "schemaVersion": 27,
-    "version": 1,
-    "refresh": "10s",
-    "time": {
-      "from": "now-15m",
-      "to": "now"
-    },
-    "timepicker": {
-      "refresh_intervals": ["5s", "10s", "30s", "1m", "5m"]
-    },
-    "annotations": {
-      "list": []
-    },
+  "id": null,
+  "uid": "taskflow-overview",
+  "title": "TaskFlow - Overview & Auto-scaling",
+  "tags": ["kubernetes", "taskflow", "autoscaling"],
+  "timezone": "browser",
+  "schemaVersion": 27,
+  "version": 1,
+  "refresh": "10s",
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m"]
+  },
+  "annotations": {
+    "list": []
+  },
     "panels": [
       {
         "id": 1,
@@ -517,5 +516,4 @@
         "tooltip": {"shared": true}
       }
     ]
-  }
 }

--- a/tp10/24-grafana-dashboard-configmap.yaml
+++ b/tp10/24-grafana-dashboard-configmap.yaml
@@ -9,25 +9,24 @@ metadata:
 data:
   taskflow-overview.json: |
     {
-      "dashboard": {
-        "id": null,
-        "uid": "taskflow-overview",
-        "title": "TaskFlow - Overview & Auto-scaling",
-        "tags": ["kubernetes", "taskflow", "autoscaling"],
-        "timezone": "browser",
-        "schemaVersion": 27,
-        "version": 1,
-        "refresh": "10s",
-        "time": {
-          "from": "now-15m",
-          "to": "now"
-        },
-        "timepicker": {
-          "refresh_intervals": ["5s", "10s", "30s", "1m", "5m"]
-        },
-        "annotations": {
-          "list": []
-        },
+      "id": null,
+      "uid": "taskflow-overview",
+      "title": "TaskFlow - Overview & Auto-scaling",
+      "tags": ["kubernetes", "taskflow", "autoscaling"],
+      "timezone": "browser",
+      "schemaVersion": 27,
+      "version": 1,
+      "refresh": "10s",
+      "time": {
+        "from": "now-15m",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": ["5s", "10s", "30s", "1m", "5m"]
+      },
+      "annotations": {
+        "list": []
+      },
         "panels": [
           {
             "id": 1,
@@ -527,5 +526,4 @@ data:
             "tooltip": {"shared": true}
           }
         ]
-      }
     }


### PR DESCRIPTION
Le dashboard utilisait le format API REST {"dashboard": {...}} au lieu du format provisioning direct attendu par Grafana.

Changements:
- Retrait de l'enveloppe "dashboard" dans ConfigMap (24-grafana-dashboard-configmap.yaml)
- Retrait de l'enveloppe "dashboard" dans fichier JSON standalone (23-grafana-dashboard-taskflow.json)
- Le dashboard sera maintenant visible au démarrage de Grafana

Le provisioning Grafana attend le JSON du dashboard directement, pas l'enveloppe utilisée par l'API REST.

Fixes: Dashboards TaskFlow non visibles dans Grafana UI