### PR TITLE
Fix missing data in Tasklow dashboard

### DIFF
--- a/tp10/09-backend-app-code.yaml
+++ b/tp10/09-backend-app-code.yaml
@@ -11,10 +11,70 @@ data:
     import time
     import psycopg2
     import redis
-    from flask import Flask, jsonify, request
+    from flask import Flask, jsonify, request, Response
     from psycopg2.extras import RealDictCursor
+    from prometheus_client import Counter, Histogram, Gauge, generate_latest, CollectorRegistry, CONTENT_TYPE_LATEST
 
     app = Flask(__name__)
+
+    # ============================================
+    # PROMETHEUS METRICS
+    # ============================================
+    registry = CollectorRegistry()
+
+    # Compteurs de requêtes HTTP
+    http_requests_total = Counter(
+        'http_requests_total',
+        'Total des requêtes HTTP',
+        ['method', 'endpoint', 'status'],
+        registry=registry
+    )
+
+    # Histogramme de latence des requêtes
+    http_request_duration_seconds = Histogram(
+        'http_request_duration_seconds',
+        'Durée des requêtes HTTP en secondes',
+        ['method', 'endpoint'],
+        registry=registry
+    )
+
+    # Gauges pour les métriques de base de données
+    database_connections_active = Gauge(
+        'database_connections_active',
+        'Nombre de connexions actives à la base de données',
+        registry=registry
+    )
+
+    tasks_total = Gauge(
+        'tasks_total',
+        'Nombre total de tâches',
+        registry=registry
+    )
+
+    tasks_completed = Gauge(
+        'tasks_completed',
+        'Nombre de tâches complétées',
+        registry=registry
+    )
+
+    tasks_pending = Gauge(
+        'tasks_pending',
+        'Nombre de tâches en attente',
+        registry=registry
+    )
+
+    # Compteur de hits/miss du cache Redis
+    cache_hits_total = Counter(
+        'cache_hits_total',
+        'Nombre de hits du cache Redis',
+        registry=registry
+    )
+
+    cache_misses_total = Counter(
+        'cache_misses_total',
+        'Nombre de miss du cache Redis',
+        registry=registry
+    )
 
     # Configuration depuis les variables d'environnement
     DB_CONFIG = {
@@ -48,13 +108,18 @@ data:
     def get_cached(key):
         """Récupérer depuis le cache Redis"""
         if redis_client is None:
+            cache_misses_total.inc()
             return None
         try:
             data = redis_client.get(key)
             if data:
+                cache_hits_total.inc()
                 return json.loads(data)
+            else:
+                cache_misses_total.inc()
         except Exception as e:
             print(f"Cache get error: {e}")
+            cache_misses_total.inc()
         return None
 
     def set_cached(key, value, ttl=CACHE_TTL):
@@ -66,9 +131,36 @@ data:
         except Exception as e:
             print(f"Cache set error: {e}")
 
+    @app.route('/metrics')
+    def metrics():
+        """Endpoint pour exposer les métriques Prometheus"""
+        # Mettre à jour les métriques de tâches avant d'exposer
+        try:
+            conn = get_db_connection()
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT
+                    COUNT(*) as total,
+                    SUM(CASE WHEN completed THEN 1 ELSE 0 END) as completed,
+                    SUM(CASE WHEN NOT completed THEN 1 ELSE 0 END) as pending
+                FROM tasks
+            """)
+            stats = cursor.fetchone()
+            cursor.close()
+            conn.close()
+
+            tasks_total.set(int(stats['total']))
+            tasks_completed.set(int(stats['completed']))
+            tasks_pending.set(int(stats['pending']))
+        except Exception as e:
+            print(f"Error updating task metrics: {e}")
+
+        return Response(generate_latest(registry), mimetype=CONTENT_TYPE_LATEST)
+
     @app.route('/health')
     def health():
         """Health check endpoint"""
+        http_requests_total.labels(method='GET', endpoint='/health', status='200').inc()
         return jsonify({'status': 'healthy', 'service': 'taskflow-api'}), 200
 
     @app.route('/ready')
@@ -81,13 +173,17 @@ data:
             cursor.execute('SELECT 1')
             cursor.close()
             conn.close()
+            http_requests_total.labels(method='GET', endpoint='/ready', status='200').inc()
             return jsonify({'status': 'ready', 'database': 'connected'}), 200
         except Exception as e:
+            http_requests_total.labels(method='GET', endpoint='/ready', status='503').inc()
             return jsonify({'status': 'not ready', 'error': str(e)}), 503
 
     @app.route('/tasks', methods=['GET'])
     def get_tasks():
         """Récupérer les tâches (avec filtres optionnels)"""
+        start_time = time.time()
+
         # Paramètres de requête
         priority = request.args.get('priority')
         completed = request.args.get('completed')
@@ -150,6 +246,11 @@ data:
         # Mettre en cache
         set_cached(cache_key, result)
 
+        # Enregistrer les métriques
+        duration = time.time() - start_time
+        http_request_duration_seconds.labels(method='GET', endpoint='/tasks').observe(duration)
+        http_requests_total.labels(method='GET', endpoint='/tasks', status='200').inc()
+
         return jsonify(result), 200
 
     @app.route('/tasks/<int:task_id>', methods=['GET'])
@@ -181,6 +282,7 @@ data:
     @app.route('/stats', methods=['GET'])
     def get_stats():
         """Récupérer les statistiques globales"""
+        start_time = time.time()
         cache_key = "stats:global"
 
         cached_data = get_cached(cache_key)
@@ -217,6 +319,11 @@ data:
         }
 
         set_cached(cache_key, result, ttl=60)
+
+        # Enregistrer les métriques
+        duration = time.time() - start_time
+        http_request_duration_seconds.labels(method='GET', endpoint='/stats').observe(duration)
+        http_requests_total.labels(method='GET', endpoint='/stats', status='200').inc()
 
         return jsonify(result), 200
 

--- a/tp10/09-backend-deployment.yaml
+++ b/tp10/09-backend-deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         app: backend-api
         tier: application
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "5000"
+        prometheus.io/path: "/metrics"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/tp10/15-prometheus-config.yaml
+++ b/tp10/15-prometheus-config.yaml
@@ -17,10 +17,33 @@ data:
             names:
             - taskflow
         relabel_configs:
-        - source_labels: [__meta_kubernetes_pod_label_app]
+        # Ne garder que les pods avec l'annotation prometheus.io/scrape=true
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
           action: keep
-          regex: backend-api|postgres|redis
+          regex: true
+        # Utiliser le port spécifié dans l'annotation prometheus.io/port
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          target_label: __address__
+          regex: (.+)
+          replacement: ${1}
+        # Utiliser le chemin spécifié dans l'annotation prometheus.io/path (défaut: /metrics)
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        # Ajouter le nom du pod comme label
         - source_labels: [__meta_kubernetes_pod_name]
           target_label: pod
+        # Ajouter le label app du pod
         - source_labels: [__meta_kubernetes_pod_label_app]
           target_label: app
+        # Ajouter le namespace comme label
+        - source_labels: [__meta_kubernetes_namespace]
+          target_label: namespace
+        # Corriger l'adresse avec l'IP du pod et le port annoté
+        - source_labels: [__meta_kubernetes_pod_ip, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__


### PR DESCRIPTION
…configuration Prometheus

Problème résolu:
- Le dashboard Grafana "TaskFlow - Overview & Auto-scaling" ne recevait aucune donnée
- L'application backend Flask n'exposait pas de métriques Prometheus
- Les pods backend n'avaient pas d'annotations Prometheus
- La configuration Prometheus ne scrapait pas les métriques correctement

Modifications apportées:

1. Backend Flask (09-backend-app-code.yaml): ✅ Ajout de la bibliothèque prometheus_client ✅ Création de métriques Prometheus: - http_requests_total (Counter) : nombre de requêtes HTTP - http_request_duration_seconds (Histogram) : latence des requêtes - tasks_total, tasks_completed, tasks_pending (Gauge) : métriques métier - cache_hits_total, cache_misses_total (Counter) : métriques Redis ✅ Ajout endpoint /metrics pour exposer les métriques ✅ Instrumentation des endpoints existants (/tasks, /stats, /health, /ready)

2. Backend Deployment (09-backend-deployment.yaml): ✅ Ajout annotations Prometheus sur les pods: - prometheus.io/scrape: "true" - prometheus.io/port: "5000" - prometheus.io/path: "/metrics"

3. Configuration Prometheus (15-prometheus-config.yaml): ✅ Configuration relabel pour découverte automatique via annotations ✅ Scraping des pods annotés avec prometheus.io/scrape=true ✅ Utilisation du port et path depuis les annotations ✅ Ajout labels: pod, app, namespace

Résultat attendu:
- ✅ Prometheus scrappe les métriques backend toutes les 15s
- ✅ Grafana affiche les données dans le dashboard
- ✅ Métriques d'auto-scaling visibles (nombre de pods HPA)
- ✅ Métriques métier visibles (tâches, cache Redis)

Prochaines étapes:
- Redéployer les composants modifiés (backend + prometheus)
- Vérifier dans Prometheus: Status > Targets
- Vérifier dans Grafana: le dashboard affiche les données