### PR TITLE
fix(tp10): Ajouter dépendance prometheus-client manquante

### DIFF
--- a/tp10/requirements.txt
+++ b/tp10/requirements.txt
@@ -10,5 +10,8 @@ psycopg2-binary==2.9.9
 # Cache
 redis==5.0.1
 
+# Monitoring
+prometheus-client==0.19.0
+
 # Utils (déjà inclus avec Flask mais explicite)
 werkzeug==3.0.1


### PR DESCRIPTION
Le backend-api crashait au démarrage avec :
ModuleNotFoundError: No module named 'prometheus_client'

Cause : Le ConfigMap backend-app-code contient un app.py qui importe prometheus_client, mais requirements.txt n'incluait pas cette dépendance.

Solution : Ajout de prometheus-client==0.19.0 dans requirements.txt

Fixes: Backend API startup crash