### PR TITLE
Fix GitHub Actions workflow paths configuration

### DIFF
--- a/.github/workflows/test-kubernetes-manifests.yml
+++ b/.github/workflows/test-kubernetes-manifests.yml
@@ -4,21 +4,23 @@ on:
   push:
     branches: [ main, claude/** ]
     paths:
-      - 'tp*/**'
-      - 'docs/**'
+      - 'tp*/**/*.yaml'
+      - 'tp*/**/*.yml'
+      - 'tp*/**/*.sh'
+      - 'tp*/**/Dockerfile'
+      - 'docs/**/*.yaml'
+      - 'docs/**/*.yml'
       - '.github/workflows/**'
-    paths-ignore:
-      - '**/*.md'
-      - '.claude/**'
   pull_request:
     branches: [ main ]
     paths:
-      - 'tp*/**'
-      - 'docs/**'
+      - 'tp*/**/*.yaml'
+      - 'tp*/**/*.yml'
+      - 'tp*/**/*.sh'
+      - 'tp*/**/Dockerfile'
+      - 'docs/**/*.yaml'
+      - 'docs/**/*.yml'
       - '.github/workflows/**'
-    paths-ignore:
-      - '**/*.md'
-      - '.claude/**'
 
 jobs:
   validate-yaml-syntax:


### PR DESCRIPTION
Problème :
- GitHub Actions ne permet pas d'utiliser à la fois `paths` et `paths-ignore` pour un même événement
- Cela causait une erreur de validation du workflow

Solution :
- Remplacer par `paths` uniquement avec des patterns spécifiques
- Cibler explicitement les fichiers pertinents (YAML, scripts, Dockerfiles)
- Exclure implicitement les fichiers markdown et la config Claude

Patterns ajoutés :
- tp*/**/*.yaml, tp*/**/*.yml (manifests Kubernetes)
- tp*/**/*.sh (scripts de test)
- tp*/**/Dockerfile (images Docker)
- docs/**/*.yaml, docs/**/*.yml (documentation)
- .github/workflows/** (workflows CI/CD)

Référence : GitHub Actions workflow syntax documentation