### PR TITLE
fix(manifests): supprimer les tags :latest — épingler les versions stables

### DIFF
--- a/tp06/.github/workflows/cd.yml
+++ b/tp06/.github/workflows/cd.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Run smoke tests
       run: |
-        kubectl run smoke-test --image=curlimages/curl:latest --rm -i --restart=Never \
+        kubectl run smoke-test --image=curlimages/curl:8.11.1 --rm -i --restart=Never \
           -- curl -f http://my-app-service.production.svc.cluster.local/health
 
   notify:

--- a/tp06/02-ingress/03-multi-service-ingress.yaml
+++ b/tp06/02-ingress/03-multi-service-ingress.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: api
-        image: hashicorp/http-echo:latest
+        image: hashicorp/http-echo:0.2.3
         args:
         - "-text=API Response"
         ports:

--- a/tp06/03-deployment-strategies/06-rolling-update.yaml
+++ b/tp06/03-deployment-strategies/06-rolling-update.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: hashicorp/http-echo:latest
+        image: hashicorp/http-echo:0.2.3
         args: ["-text=Version 1"]
         ports:
         - containerPort: 5678

--- a/tp06/03-deployment-strategies/07-blue-green.yaml
+++ b/tp06/03-deployment-strategies/07-blue-green.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: hashicorp/http-echo:latest
+        image: hashicorp/http-echo:0.2.3
         args: ["-text=Blue Version"]
         ports:
         - containerPort: 5678
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: hashicorp/http-echo:latest
+        image: hashicorp/http-echo:0.2.3
         args: ["-text=Green Version"]
         ports:
         - containerPort: 5678

--- a/tp06/03-deployment-strategies/08-canary.yaml
+++ b/tp06/03-deployment-strategies/08-canary.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: hashicorp/http-echo:latest
+        image: hashicorp/http-echo:0.2.3
         args: ["-text=Stable Version"]
         ports:
         - containerPort: 5678
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: hashicorp/http-echo:latest
+        image: hashicorp/http-echo:0.2.3
         args: ["-text=Canary Version"]
         ports:
         - containerPort: 5678

--- a/tp06/03-deployment-strategies/09-ab-testing.yaml
+++ b/tp06/03-deployment-strategies/09-ab-testing.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: hashicorp/http-echo:latest
+        image: hashicorp/http-echo:0.2.3
         args: ["-text=Version 1"]
         ports:
         - containerPort: 5678
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: hashicorp/http-echo:latest
+        image: hashicorp/http-echo:0.2.3
         args: ["-text=Version 2 - New Feature"]
         ports:
         - containerPort: 5678

--- a/tp06/tekton/tasks/docker-build-task.yaml
+++ b/tp06/tekton/tasks/docker-build-task.yaml
@@ -17,7 +17,7 @@ spec:
       description: Chemin vers le Dockerfile
   steps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:latest
+      image: gcr.io/kaniko-project/executor:v1.23.2
       workingDir: $(workspaces.source.path)
       env:
         - name: DOCKER_CONFIG

--- a/tp06/tekton/tasks/helm-deploy-task.yaml
+++ b/tp06/tekton/tasks/helm-deploy-task.yaml
@@ -23,7 +23,7 @@ spec:
     - name: source
   steps:
     - name: deploy
-      image: alpine/helm:latest
+      image: alpine/helm:3.17.0
       script: |
         #!/bin/sh
         set -e

--- a/tp06/tekton/tasks/kubectl-verify-task.yaml
+++ b/tp06/tekton/tasks/kubectl-verify-task.yaml
@@ -13,7 +13,7 @@ spec:
       default: default
   steps:
     - name: verify-deployment
-      image: bitnami/kubectl:latest
+      image: bitnami/kubectl:1.32.0
       script: |
         #!/bin/sh
         set -e
@@ -24,7 +24,7 @@ spec:
         kubectl get pods -n $(params.namespace)
 
     - name: smoke-test
-      image: curlimages/curl:latest
+      image: curlimages/curl:8.11.1
       script: |
         #!/bin/sh
         set -e

--- a/tp06/tekton/tasks/trivy-scan-task.yaml
+++ b/tp06/tekton/tasks/trivy-scan-task.yaml
@@ -11,7 +11,7 @@ spec:
       description: Image à scanner
   steps:
     - name: scan
-      image: aquasec/trivy:latest
+      image: aquasec/trivy:0.59.0
       script: |
         #!/bin/sh
         set -e

--- a/tp09/examples/node-affinity-examples.yaml
+++ b/tp09/examples/node-affinity-examples.yaml
@@ -134,7 +134,7 @@ spec:
                 - high-performance
       containers:
       - name: app
-        image: myapp:latest
+        image: myapp:1.0.0
         resources:
           requests:
             memory: "512Mi"
@@ -179,7 +179,7 @@ spec:
                 - "3"
       containers:
       - name: prometheus
-        image: prom/prometheus:latest
+        image: prom/prometheus:v2.45.0
         resources:
           requests:
             memory: "2Gi"

--- a/tp09/examples/pod-affinity-examples.yaml
+++ b/tp09/examples/pod-affinity-examples.yaml
@@ -108,7 +108,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - name: service
-        image: myapp:latest
+        image: myapp:1.0.0
         ports:
         - containerPort: 8080
         resources:
@@ -388,7 +388,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: app
-        image: myapp:latest
+        image: myapp:1.0.0
         resources:
           requests:
             memory: "256Mi"

--- a/tp09/examples/poddisruptionbudget-examples.yaml
+++ b/tp09/examples/poddisruptionbudget-examples.yaml
@@ -386,7 +386,7 @@ spec:
     spec:
       containers:
       - name: agent
-        image: monitoring-agent:latest
+        image: monitoring-agent:1.0.0
         resources:
           requests:
             memory: "128Mi"

--- a/tp09/examples/taints-tolerations-examples.yaml
+++ b/tp09/examples/taints-tolerations-examples.yaml
@@ -46,7 +46,7 @@ spec:
     effect: "NoSchedule"
   containers:
   - name: admin
-    image: busybox:latest
+    image: busybox:1.36
     command: ['sh', '-c', 'sleep 3600']
 
 ---
@@ -134,7 +134,7 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: ml-training
-        image: tensorflow/tensorflow:latest-gpu
+        image: tensorflow/tensorflow:2.18.0-gpu
         command: ["python", "train.py"]
         resources:
           limits:
@@ -197,7 +197,7 @@ spec:
         effect: "PreferNoSchedule"
       containers:
       - name: app
-        image: myapp:latest
+        image: myapp:1.0.0
         resources:
           requests:
             memory: "256Mi"
@@ -236,7 +236,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        image: fluent/fluentd:latest
+        image: fluent/fluentd:v1.16-alpine
         volumeMounts:
         - name: varlog
           mountPath: /var/log
@@ -335,7 +335,7 @@ spec:
             effect: "NoExecute"
           containers:
           - name: backup
-            image: backup-tool:latest
+            image: backup-tool:1.0.0
             command: ["/bin/sh"]
             args:
             - -c


### PR DESCRIPTION
## Résumé

- Suppression de 24 occurrences de `:latest` dans 14 fichiers (tp06 et tp09)
- Chaque image est désormais épinglée sur une version stable et reproductible
- Les versions choisies sont cohérentes avec celles déjà utilisées dans le reste de la formation

## Images remplacées

| Image | Avant | Après |
|-------|-------|-------|
| `hashicorp/http-echo` | `:latest` | `0.2.3` |
| `gcr.io/kaniko-project/executor` | `:latest` | `v1.23.2` |
| `bitnami/kubectl` | `:latest` | `1.32.0` |
| `curlimages/curl` | `:latest` | `8.11.1` |
| `alpine/helm` | `:latest` | `3.17.0` |
| `aquasec/trivy` | `:latest` | `0.59.0` |
| `prom/prometheus` | `:latest` | `v2.45.0` (cohérent tp04) |
| `busybox` | `:latest` | `1.36` (cohérent tp03/04/05) |
| `tensorflow/tensorflow` | `:latest-gpu` | `2.18.0-gpu` |
| `fluent/fluentd` | `:latest` | `v1.16-alpine` (cohérent tp04) |
| `myapp` / `backup-tool` / `monitoring-agent` | `:latest` | `1.0.0` (placeholders fictifs) |

## Fichiers modifiés

- `tp06/.github/workflows/cd.yml`
- `tp06/02-ingress/03-multi-service-ingress.yaml`
- `tp06/03-deployment-strategies/06-rolling-update.yaml`
- `tp06/03-deployment-strategies/07-blue-green.yaml`
- `tp06/03-deployment-strategies/08-canary.yaml`
- `tp06/03-deployment-strategies/09-ab-testing.yaml`
- `tp06/tekton/tasks/docker-build-task.yaml`
- `tp06/tekton/tasks/helm-deploy-task.yaml`
- `tp06/tekton/tasks/kubectl-verify-task.yaml`
- `tp06/tekton/tasks/trivy-scan-task.yaml`
- `tp09/examples/node-affinity-examples.yaml`
- `tp09/examples/pod-affinity-examples.yaml`
- `tp09/examples/poddisruptionbudget-examples.yaml`
- `tp09/examples/taints-tolerations-examples.yaml`

## Plan de test
- [ ] Vérifier que `grep -rn ":latest" tp0*/ --include="*.yaml" --include="*.yml"` ne renvoie rien
- [ ] Validation kubeconform sur les fichiers modifiés

🤖 Generated with [Claude Code](https://claude.com/claude-code)