### PR TITLE
fix(tp08): remplacer tutum/dnsutils par l'image officielle Kubernetes

### DIFF
--- a/tp08/README.md
+++ b/tp08/README.md
@@ -548,7 +548,7 @@ wget -qO- http://api  # ERREUR
 
 ```bash
 # Tester la résolution DNS
-kubectl run dnsutils --image=tutum/dnsutils --rm -it -- sh
+kubectl run dnsutils --image=registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3 --rm -it -- sh
 
 # Dans le pod
 nslookup kubernetes.default

--- a/tp08/TESTS.md
+++ b/tp08/TESTS.md
@@ -264,7 +264,7 @@ kubectl delete namespace frontend backend
 
 ```bash
 # Déployer un pod avec outils DNS
-kubectl run dnsutils --image=tutum/dnsutils --rm -it -- sh
+kubectl run dnsutils --image=registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3 --rm -it -- sh
 
 # Dans le pod, tester :
 nslookup kubernetes.default


### PR DESCRIPTION
tutum/dnsutils est abandonnée et non maintenue. Remplacement par registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3, l'image de référence de la documentation officielle Kubernetes pour le débogage DNS.