### PR TITLE
feat(tp11): ajouter TP Kubernetes Gateway API — successeur d'Ingress

### DIFF
--- a/tp11/README.md
+++ b/tp11/README.md
@@ -1,0 +1,940 @@
+# TP11 - Kubernetes Gateway API : le successeur d'Ingress
+
+## Objectifs du TP
+
+Ce TP vous permettra de maîtriser la Gateway API Kubernetes, successeur officiel de l'Ingress. Vous apprendrez :
+
+- Comprendre les limites de l'Ingress et pourquoi la Gateway API le remplace
+- Maîtriser le modèle de rôles (GatewayClass, Gateway, HTTPRoute)
+- Implémenter des stratégies de routage avancées (header, chemin, poids)
+- Réaliser un déploiement canary sans changer votre code applicatif
+- Configurer la terminaison TLS au niveau du Gateway
+- Comprendre les différences avec Ingress et migrer des manifests existants
+
+**Durée estimée :** 5-7 heures
+**Niveau :** Intermédiaire à Avancé
+
+## Prérequis
+
+- Avoir complété le TP8 (réseau Kubernetes et Services)
+- Cluster Kubernetes ≥ 1.28 (Gateway API v1 stable)
+- kubectl installé et configuré
+- helm installé (pour déployer l'implémentation)
+- Notions de DNS, HTTP et TLS
+
+## Table des matières
+
+- [Partie 1 : Pourquoi remplacer l'Ingress ?](#partie-1--pourquoi-remplacer-lingress-)
+- [Partie 2 : Architecture et modèle de rôles](#partie-2--architecture-et-modèle-de-rôles)
+- [Partie 3 : Installation et mise en place](#partie-3--installation-et-mise-en-place)
+- [Partie 4 : GatewayClass et Gateway](#partie-4--gatewayclass-et-gateway)
+- [Partie 5 : HTTPRoute — routage basique](#partie-5--httproute--routage-basique)
+- [Partie 6 : Routage avancé](#partie-6--routage-avancé)
+- [Partie 7 : Traffic splitting et canary deployments](#partie-7--traffic-splitting-et-canary-deployments)
+- [Partie 8 : TLS et sécurité](#partie-8--tls-et-sécurité)
+- [Partie 9 : Migration depuis Ingress](#partie-9--migration-depuis-ingress)
+- [Exercices pratiques](#exercices-pratiques)
+
+---
+
+## Partie 1 : Pourquoi remplacer l'Ingress ?
+
+### 1.1 Les limites de l'Ingress
+
+L'Ingress a été introduit en Kubernetes 1.1 et a très bien servi pendant des années. Mais il souffre de plusieurs limitations structurelles.
+
+**L'annotation hell**
+
+Pour faire du routage par header avec nginx Ingress, il fallait écrire :
+
+```yaml
+annotations:
+  nginx.ingress.kubernetes.io/canary: "true"
+  nginx.ingress.kubernetes.io/canary-weight: "20"
+  nginx.ingress.kubernetes.io/canary-by-header: "X-Canary"
+```
+
+Ces annotations sont propres à nginx. La même configuration avec Traefik est différente. Résultat : vous êtes verrouillé sur votre implémentation.
+
+**Pas de RBAC natif**
+
+Avec l'Ingress, n'importe quel développeur peut modifier les règles de routage globales du cluster. Il n'existe pas de séparation native entre la configuration de l'infrastructure (qui écoute sur quel port, quel certificat) et les règles applicatives.
+
+**Expressivité limitée**
+
+L'Ingress ne supporte nativement que :
+- Le routage par hostname
+- Le routage par chemin (PathPrefix)
+
+Tout le reste (header matching, traffic splitting, redirection, réécriture) passe par des annotations non standardisées.
+
+### 1.2 Ce que la Gateway API apporte
+
+| Fonctionnalité | Ingress | Gateway API |
+|---|---|---|
+| Routage par chemin | ✅ via annotation | ✅ natif |
+| Routage par header | ⚠️ vendor annotation | ✅ natif |
+| Traffic splitting | ⚠️ vendor annotation | ✅ natif (weights) |
+| Réécriture d'URL | ⚠️ vendor annotation | ✅ natif (filtres) |
+| TLS | ✅ basique | ✅ avancé |
+| RBAC natif | ❌ | ✅ via modèle de rôles |
+| Protocoles | HTTP/HTTPS | HTTP, HTTPS, gRPC, TCP, TLS |
+| Portabilité | ❌ vendor lock-in | ✅ API standardisée |
+
+**Statut de stabilité :**
+- `GatewayClass`, `Gateway`, `HTTPRoute` → **GA (v1)** depuis Kubernetes 1.28
+- `GRPCRoute` → **GA (v1)** depuis Kubernetes 1.31
+- `TCPRoute`, `TLSRoute` → **Expérimental** (v1alpha2)
+
+---
+
+## Partie 2 : Architecture et modèle de rôles
+
+### 2.1 Trois personas, trois ressources
+
+La Gateway API est conçue autour d'une séparation claire des responsabilités :
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    INFRASTRUCTURE PROVIDER                       │
+│          (équipe plateforme, cloud provider)                     │
+│                                                                  │
+│   ┌──────────────────────────────────────────────────────────┐  │
+│   │  GatewayClass                                            │  │
+│   │  - Définit quel controller gère les Gateways             │  │
+│   │  - Cluster-scoped (pas de namespace)                     │  │
+│   │  - Ex: nginx, envoy, cilium, istio                       │  │
+│   └──────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      CLUSTER OPERATOR                            │
+│          (SRE, équipe ops)                                       │
+│                                                                  │
+│   ┌──────────────────────────────────────────────────────────┐  │
+│   │  Gateway                                                 │  │
+│   │  - Configure les listeners (port, protocole, TLS)        │  │
+│   │  - Définit quels namespaces peuvent attacher des routes  │  │
+│   │  - Namespaced (souvent dans un namespace dédié)          │  │
+│   └──────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    APPLICATION DEVELOPER                         │
+│          (équipes applicatives)                                  │
+│                                                                  │
+│   ┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐  │
+│   │  HTTPRoute   │  │  GRPCRoute   │  │  TCPRoute (alpha)    │  │
+│   │  - Règles    │  │  - gRPC      │  │  - TCP/TLS           │  │
+│   │    de routage│  │    routing   │  │    passthrough       │  │
+│   └──────────────┘  └──────────────┘  └──────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Flux d'une requête
+
+```
+Client HTTP
+    │
+    ▼
+┌───────────────────────────────────────────────────────────┐
+│  Gateway (Load Balancer)                                  │
+│  listener: port 80 (HTTP)                                 │
+│  listener: port 443 (HTTPS) ← terminaison TLS ici        │
+└───────────────────────────────────────────────────────────┘
+    │
+    │  parentRef → Gateway
+    ▼
+┌───────────────────────────────────────────────────────────┐
+│  HTTPRoute                                                │
+│  rules:                                                   │
+│    - match: path=/api/*  → backend-v1:80                 │
+│    - match: header X-Beta=true → backend-v2:80           │
+│    - default            → backend-v1:80 (90%) +          │
+│                            backend-v2:80 (10%)           │
+└───────────────────────────────────────────────────────────┘
+    │
+    ▼
+Service Kubernetes → Pods
+```
+
+---
+
+## Partie 3 : Installation et mise en place
+
+### 3.1 Installer les CRDs Gateway API
+
+Les CRDs sont indépendants de l'implémentation. Ils définissent les types GatewayClass, Gateway, HTTPRoute, etc.
+
+```bash
+# Canal standard (GatewayClass, Gateway, HTTPRoute, GRPCRoute)
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+
+# Vérifier les CRDs installées
+kubectl get crd | grep gateway.networking.k8s.io
+```
+
+Vous devriez voir :
+```
+gatewayclasses.gateway.networking.k8s.io
+gateways.gateway.networking.k8s.io
+grpcroutes.gateway.networking.k8s.io
+httproutes.gateway.networking.k8s.io
+referencegrants.gateway.networking.k8s.io
+```
+
+### 3.2 Installer une implémentation
+
+La Gateway API est une spécification — il faut une implémentation concrète. Deux options populaires :
+
+**Option A : nginx Gateway Fabric (recommandé pour ce TP)**
+
+nginx Gateway Fabric est le successeur officiel du nginx Ingress Controller.
+
+```bash
+# Installer nginx Gateway Fabric
+kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-gateway-fabric/v1.5.1/deploy/crds.yaml
+kubectl apply -f https://raw.githubusercontent.com/nginxinc/nginx-gateway-fabric/v1.5.1/deploy/default/deploy.yaml
+
+# Vérifier l'installation
+kubectl get pods -n nginx-gateway
+kubectl get gatewayclass nginx
+```
+
+**Option B : Envoy Gateway**
+
+```bash
+helm install eg oci://docker.io/envoyproxy/gateway-helm \
+  --version v1.3.0 \
+  -n envoy-gateway-system \
+  --create-namespace
+
+# Vérifier
+kubectl get pods -n envoy-gateway-system
+kubectl get gatewayclass eg
+```
+
+**Option C : Cilium (si utilisé comme CNI)**
+
+```bash
+# Activer Gateway API dans Cilium
+helm upgrade cilium cilium/cilium \
+  --set gatewayAPI.enabled=true
+
+kubectl get gatewayclass cilium
+```
+
+### 3.3 Préparer l'environnement de TP
+
+```bash
+# Créer le namespace de travail
+kubectl apply -f examples/01-namespace.yaml
+
+# Vérifier
+kubectl get namespace tp11
+```
+
+---
+
+## Partie 4 : GatewayClass et Gateway
+
+### 4.1 GatewayClass
+
+La `GatewayClass` est l'équivalent de l'`IngressClass`. Elle est cluster-scoped et désigne quel controller prend en charge les Gateways.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: nginx
+spec:
+  controllerName: gateway.nginx.org/nginx-gateway-controller
+```
+
+```bash
+# Appliquer
+kubectl apply -f examples/02-gatewayclass.yaml
+
+# Vérifier le statut
+kubectl get gatewayclass nginx
+# ACCEPTED = le controller a pris en charge la GatewayClass
+
+kubectl describe gatewayclass nginx
+```
+
+**Points clés :**
+- Une seule `GatewayClass` par implémentation
+- Le champ `controllerName` est défini par le fabricant de l'implémentation
+- `ACCEPTED` dans `STATUS` confirme que le controller est actif
+
+### 4.2 Gateway
+
+La `Gateway` configure ce que le load balancer doit écouter : ports, protocoles, et restrictions d'accès.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: main-gateway
+  namespace: tp11
+spec:
+  gatewayClassName: nginx
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same     # Seules les routes du même namespace peuvent s'attacher
+  - name: https
+    protocol: HTTPS
+    port: 443
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: tls-secret
+    allowedRoutes:
+      namespaces:
+        from: Same
+```
+
+**La politique `allowedRoutes` :**
+
+| Valeur | Comportement |
+|---|---|
+| `Same` | Seul le namespace du Gateway peut attacher des routes |
+| `All` | Tous les namespaces peuvent attacher des routes |
+| `Selector` | Seuls les namespaces matchant les labels peuvent attacher des routes |
+
+```bash
+# Appliquer
+kubectl apply -f examples/03-gateway.yaml
+
+# Vérifier (PROGRAMMED = infrastructure provisionnée)
+kubectl get gateway -n tp11
+kubectl describe gateway main-gateway -n tp11
+
+# Obtenir l'IP externe du Gateway
+kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}'
+```
+
+**Exercice 4.1 :**
+
+```bash
+# Décrire le Gateway et identifier dans le statut :
+# 1. L'adresse IP assignée
+# 2. Les listeners actifs
+# 3. Le nombre de routes attachées
+kubectl describe gateway main-gateway -n tp11
+```
+
+---
+
+## Partie 5 : HTTPRoute — routage basique
+
+### 5.1 Structure d'une HTTPRoute
+
+L'HTTPRoute est la ressource que le développeur applicatif manipule au quotidien. Elle s'attache à un Gateway via `parentRefs`.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ma-route
+  namespace: tp11
+spec:
+  parentRefs:
+  - name: main-gateway      # Gateway cible
+    namespace: tp11
+    sectionName: http        # Listener spécifique (optionnel)
+  hostnames:
+  - "app.example.com"        # Filtrage par hostname (optionnel)
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /api
+    backendRefs:
+    - name: backend-v1
+      port: 80
+```
+
+### 5.2 Types de matching de chemin
+
+| Type | Exemple | Comportement |
+|---|---|---|
+| `Exact` | `/api/users` | Correspond exactement à ce chemin |
+| `PathPrefix` | `/api` | Correspond à `/api`, `/api/users`, `/api/v2/...` |
+| `RegularExpression` | `/api/v[0-9]+` | Expression régulière (support selon implémentation) |
+
+### 5.3 Déployer les backends et la route basique
+
+```bash
+# Déployer les services backend
+kubectl apply -f examples/04-backend-v1.yaml
+kubectl apply -f examples/05-backend-v2.yaml
+
+# Vérifier les pods
+kubectl get pods -n tp11
+kubectl get services -n tp11
+
+# Appliquer la route basique
+kubectl apply -f examples/06-httproute-basic.yaml
+
+# Vérifier le statut de la route
+kubectl get httproute -n tp11
+kubectl describe httproute basic-routing -n tp11
+```
+
+**Tester le routage :**
+
+```bash
+# Récupérer l'IP du Gateway
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Tester les différents chemins
+curl -H "Host: app.example.com" http://$GW_IP/api
+curl -H "Host: app.example.com" http://$GW_IP/web
+curl -H "Host: app.example.com" http://$GW_IP/
+```
+
+**Exercice 5.1 : Observer le statut d'attachement**
+
+```bash
+# Une route bien configurée doit afficher "Accepted: True" et "ResolvedRefs: True"
+kubectl describe httproute basic-routing -n tp11 | grep -A 5 "Conditions"
+
+# Que se passe-t-il si vous référencez un Service qui n'existe pas ?
+# Modifier temporairement backendRefs pour pointer vers "inexistant:80"
+# Observer le changement de statut
+```
+
+---
+
+## Partie 6 : Routage avancé
+
+### 6.1 Routage par header
+
+Le routage par header permet de l'A/B testing ou du routage conditionnel sans toucher à l'infrastructure.
+
+```yaml
+rules:
+- matches:
+  - headers:
+    - name: X-Version
+      value: v2
+  backendRefs:
+  - name: backend-v2
+    port: 80
+- backendRefs:          # Règle par défaut (pas de match = toutes les autres requêtes)
+  - name: backend-v1
+    port: 80
+```
+
+**Important :** Les règles sont évaluées dans l'ordre. La première qui matche gagne.
+
+```bash
+kubectl apply -f examples/07-httproute-header-routing.yaml
+
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Sans header → v1
+curl -H "Host: ab.example.com" http://$GW_IP/
+
+# Avec header → v2
+curl -H "Host: ab.example.com" -H "X-Version: v2" http://$GW_IP/
+```
+
+### 6.2 Autres types de matching
+
+**Par query parameter :**
+
+```yaml
+matches:
+- queryParams:
+  - name: debug
+    value: "true"
+```
+
+**Par méthode HTTP :**
+
+```yaml
+matches:
+- method: POST
+```
+
+**Combinaison de critères (ET logique) :**
+
+```yaml
+matches:
+- path:
+    type: PathPrefix
+    value: /api
+  headers:
+  - name: X-Env
+    value: staging
+  method: POST
+```
+
+**Plusieurs entrées dans `matches` (OU logique) :**
+
+```yaml
+matches:
+- path:
+    type: Exact
+    value: /health
+- path:
+    type: Exact
+    value: /ping
+```
+
+### 6.3 Filtres (transformations)
+
+**Réécriture de chemin :**
+
+```yaml
+filters:
+- type: URLRewrite
+  urlRewrite:
+    path:
+      type: ReplacePrefixMatch
+      replacePrefixMatch: /api    # /old-api/users → /api/users
+```
+
+**Redirection :**
+
+```yaml
+filters:
+- type: RequestRedirect
+  requestRedirect:
+    scheme: https
+    statusCode: 301
+```
+
+**Ajout de headers :**
+
+```yaml
+filters:
+- type: RequestHeaderModifier
+  requestHeaderModifier:
+    add:
+    - name: X-Forwarded-Source
+      value: gateway
+    remove:
+    - X-Internal-Debug
+```
+
+```bash
+kubectl apply -f examples/09-httproute-rewrite.yaml
+
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Tester la réécriture : /old-api → /api
+curl -v -H "Host: rewrite.example.com" http://$GW_IP/old-api/users
+
+# Tester la redirection
+curl -v -H "Host: rewrite.example.com" http://$GW_IP/redirect
+```
+
+**Exercice 6.1 : Combiner les filtres**
+
+Créer une HTTPRoute qui :
+1. Accepte les requêtes sur `/legacy/*`
+2. Réécrit le chemin vers `/v2/*`
+3. Ajoute le header `X-Migrated: true`
+
+---
+
+## Partie 7 : Traffic splitting et canary deployments
+
+### 7.1 Le concept de weight
+
+Chaque `backendRef` accepte un champ `weight`. La somme des poids dans une règle détermine la distribution du trafic.
+
+```yaml
+rules:
+- backendRefs:
+  - name: backend-v1
+    port: 80
+    weight: 90    # 90/(90+10) = 90% du trafic
+  - name: backend-v2
+    port: 80
+    weight: 10    # 10/(90+10) = 10% du trafic
+```
+
+Si `weight` est omis, sa valeur par défaut est `1`.
+
+### 7.2 Déploiement canary progressif
+
+Le canary deployment consiste à envoyer un faible pourcentage du trafic vers la nouvelle version, observer les métriques, puis progressivement augmenter.
+
+```
+Étape 1 : 100%/0%   → baseline, tout sur v1
+Étape 2 :  80%/20%  → canary early adopters
+Étape 3 :  50%/50%  → validation à mi-chemin
+Étape 4 :   0%/100% → bascule complète vers v2
+Rollback :  si anomalie, revenir à 100%/0% immédiatement
+```
+
+```bash
+kubectl apply -f examples/08-httproute-canary.yaml
+
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Simuler 20 requêtes et compter la distribution
+for i in $(seq 1 20); do
+  curl -s -H "Host: canary.example.com" http://$GW_IP/ | grep -o 'v[12]'
+done | sort | uniq -c
+# Résultat attendu : ~18 v1, ~2 v2
+
+# Modifier le weight à 50/50
+kubectl patch httproute canary-routing -n tp11 --type='json' \
+  -p='[{"op":"replace","path":"/spec/rules/0/backendRefs/0/weight","value":50},
+       {"op":"replace","path":"/spec/rules/0/backendRefs/1/weight","value":50}]'
+
+# Tester à nouveau
+for i in $(seq 1 20); do
+  curl -s -H "Host: canary.example.com" http://$GW_IP/ | grep -o 'v[12]'
+done | sort | uniq -c
+```
+
+### 7.3 Combinaison canary + header routing
+
+Une stratégie plus fine : exposer la nouvelle version uniquement aux utilisateurs qui ont opté pour le programme bêta.
+
+```yaml
+rules:
+# Les beta-testeurs voient v2
+- matches:
+  - headers:
+    - name: X-Beta-User
+      value: "true"
+  backendRefs:
+  - name: backend-v2
+    port: 80
+
+# 10% du reste voit aussi v2 (canary passif)
+- backendRefs:
+  - name: backend-v1
+    port: 80
+    weight: 90
+  - name: backend-v2
+    port: 80
+    weight: 10
+```
+
+**Exercice 7.1 : Blue/Green avec bascule instantanée**
+
+```bash
+# Déployer deux environnements : blue (v1) et green (v2)
+# Créer une HTTPRoute qui envoie tout vers blue
+
+# Pour basculer vers green, modifier le weight :
+kubectl patch httproute <nom-route> -n tp11 --type='json' \
+  -p='[{"op":"replace","path":"/spec/rules/0/backendRefs/0/weight","value":0},
+       {"op":"replace","path":"/spec/rules/0/backendRefs/1/weight","value":100}]'
+
+# La bascule est quasi-instantanée (pas de redéploiement nécessaire)
+```
+
+---
+
+## Partie 8 : TLS et sécurité
+
+### 8.1 Terminaison TLS
+
+La terminaison TLS se configure au niveau du `Gateway`, pas de la route. Le certificat est référencé depuis un Secret Kubernetes.
+
+```bash
+# Créer un certificat auto-signé pour les tests
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout tls.key -out tls.crt \
+  -subj "/CN=secure.example.com" \
+  -addext "subjectAltName=DNS:secure.example.com"
+
+# Créer le Secret
+kubectl create secret tls tls-secret \
+  --cert=tls.crt \
+  --key=tls.key \
+  -n tp11
+
+# Vérifier
+kubectl get secret tls-secret -n tp11
+```
+
+Le listener HTTPS est déjà défini dans `examples/03-gateway.yaml`. L'HTTPRoute TLS s'attache au listener `https` via `sectionName` :
+
+```bash
+kubectl apply -f examples/10-httproute-tls.yaml
+
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Tester HTTPS (--insecure car certificat auto-signé)
+curl -k -H "Host: secure.example.com" https://$GW_IP/
+```
+
+### 8.2 ReferenceGrant : accès cross-namespace
+
+Par défaut, un `Gateway` dans `namespace-a` ne peut pas référencer un `Secret` dans `namespace-b`. Le `ReferenceGrant` permet d'autoriser explicitement cet accès.
+
+```yaml
+# Dans le namespace qui contient le Secret
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-gateway-tls
+  namespace: cert-store          # Namespace du Secret
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    namespace: infra             # Namespace du Gateway autorisé
+  to:
+  - group: ""
+    kind: Secret
+    name: wildcard-tls           # Nom du Secret autorisé
+```
+
+Le même mécanisme s'applique quand une HTTPRoute dans `app-namespace` veut cibler un Service dans `shared-services`.
+
+### 8.3 Redirect HTTP → HTTPS automatique
+
+```yaml
+# Route sur le listener HTTP qui redirige tout vers HTTPS
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-redirect
+  namespace: tp11
+spec:
+  parentRefs:
+  - name: main-gateway
+    namespace: tp11
+    sectionName: http         # Listener HTTP
+  rules:
+  - filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        statusCode: 301
+```
+
+---
+
+## Partie 9 : Migration depuis Ingress
+
+### 9.1 Correspondance des concepts
+
+| Ingress | Gateway API | Notes |
+|---|---|---|
+| `IngressClass` | `GatewayClass` | Cluster-scoped dans les deux cas |
+| `Ingress` | `Gateway` + `HTTPRoute` | Séparation infrastructure/applicatif |
+| `spec.rules[].host` | `spec.hostnames` | Dans HTTPRoute |
+| `spec.rules[].http.paths` | `spec.rules[].matches` | Même logique |
+| `spec.tls` | Listener `HTTPS` dans Gateway | TLS géré au niveau Gateway |
+| annotations vendor | Filtres natifs | Portables entre implémentations |
+
+### 9.2 Exemple de migration
+
+**Avant (Ingress) :**
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /api/$2
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: app.example.com
+    http:
+      paths:
+      - path: /old-api(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: backend
+            port:
+              number: 80
+```
+
+**Après (Gateway API) :**
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: my-route
+  namespace: default
+spec:
+  parentRefs:
+  - name: main-gateway
+    namespace: infra
+  hostnames:
+  - "app.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /old-api
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /api
+    backendRefs:
+    - name: backend
+      port: 80
+```
+
+**Ce qui change :**
+- Plus d'annotation `rewrite-target` : le filtre `URLRewrite` est portable
+- La configuration TLS sort de l'Ingress et va dans le Gateway
+- L'opérateur contrôle la politique d'accès via `allowedRoutes`
+
+### 9.3 Coexistence Ingress et Gateway API
+
+Pendant la migration, les deux peuvent coexister dans le même cluster. Un Service peut être ciblé simultanément par un Ingress existant et une HTTPRoute.
+
+```bash
+# Vérifier les deux types de ressources
+kubectl get ingress -A
+kubectl get httproute -A
+```
+
+---
+
+## Exercices pratiques
+
+### Exercice 1 : Gateway simple avec deux services
+
+**Objectif :** Exposer un frontend et une API sur le même hostname avec des chemins distincts.
+
+```bash
+kubectl apply -f exercices/exercice-1-simple-gateway.yaml
+```
+
+Compléter les sections `<COMPLÉTER>` dans le fichier puis valider :
+
+```bash
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Doit répondre "frontend"
+curl -H "Host: exercice1.example.com" http://$GW_IP/
+
+# Doit répondre {"service":"api","version":"1.0"}
+curl -H "Host: exercice1.example.com" http://$GW_IP/api/
+```
+
+**Questions :**
+1. Que se passe-t-il si vous intervertissez l'ordre des règles ?
+2. Comment restreindre l'accès à `/api/*` aux seules requêtes avec le header `Authorization` ?
+
+### Exercice 2 : Canary deployment progressif
+
+**Objectif :** Simuler les 3 étapes d'un déploiement canary en modifiant uniquement les weights.
+
+```bash
+kubectl apply -f exercices/exercice-2-canary-deployment.yaml
+```
+
+```bash
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Script de test de distribution
+check_distribution() {
+  local total=20
+  echo "=== Distribution sur $total requêtes ==="
+  for i in $(seq 1 $total); do
+    curl -s -H "Host: canary-ex.example.com" http://$GW_IP/ 2>/dev/null
+  done | sort | uniq -c
+}
+
+# Étape 1 : 100% stable (weights: 100/0)
+check_distribution
+
+# Étape 2 : 80% stable, 20% canary — modifier le fichier et appliquer
+# kubectl apply -f exercices/exercice-2-canary-deployment.yaml
+check_distribution
+
+# Étape 3 : 100% canary (weights: 0/100)
+check_distribution
+```
+
+**Questions :**
+1. La distribution est-elle exactement 80/20 ou approximative ? Pourquoi ?
+2. Comment implémenteriez-vous un rollback automatique si les erreurs dépassent 5% ?
+
+### Exercice 3 : HTTPRoute cross-namespace avec ReferenceGrant
+
+**Objectif :** Permettre à une HTTPRoute dans `team-a` de cibler un Service dans `shared-services`.
+
+```bash
+# Créer les namespaces
+kubectl create namespace team-a
+kubectl create namespace shared-services
+
+# Déployer le service partagé dans shared-services
+kubectl run shared-api --image=nginx:1.27-alpine -n shared-services --port=80
+kubectl expose pod shared-api --port=80 -n shared-services
+
+# TODO : Créer le ReferenceGrant dans shared-services
+# TODO : Créer l'HTTPRoute dans team-a qui cible shared-api dans shared-services
+```
+
+**Questions :**
+1. Que se passe-t-il si vous appliquez l'HTTPRoute sans le ReferenceGrant ?
+2. À quoi sert la granularité `name` dans le ReferenceGrant ?
+
+---
+
+## Nettoyage
+
+```bash
+# Supprimer toutes les ressources du TP
+kubectl delete namespace tp11
+kubectl delete namespace team-a
+kubectl delete namespace shared-services
+
+# Supprimer la GatewayClass (cluster-scoped)
+kubectl delete gatewayclass nginx
+
+# Optionnel : désinstaller l'implémentation
+kubectl delete -f https://raw.githubusercontent.com/nginxinc/nginx-gateway-fabric/v1.5.1/deploy/default/deploy.yaml
+
+# Supprimer les CRDs Gateway API
+kubectl delete -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+```
+
+---
+
+## Récapitulatif
+
+| Concept | Ressource | Qui la gère |
+|---|---|---|
+| Type d'implémentation | `GatewayClass` | Infrastructure provider |
+| Listeners (ports, TLS) | `Gateway` | Cluster operator |
+| Règles de routage HTTP | `HTTPRoute` | Développeur applicatif |
+| Règles gRPC | `GRPCRoute` | Développeur applicatif |
+| Autorisation cross-namespace | `ReferenceGrant` | Owner du namespace cible |
+
+**Points clés à retenir :**
+- La Gateway API est **stable (GA)** depuis Kubernetes 1.28 — utilisable en production
+- Le **traffic splitting natif** (`weight`) remplace les annotations canary vendor-specific
+- Les **filtres** (`URLRewrite`, `RequestRedirect`, `RequestHeaderModifier`) sont portables entre implémentations
+- `allowedRoutes` sur le Gateway implémente le RBAC réseau sans configuration RBAC supplémentaire
+- Un même `Service` peut être ciblé par plusieurs HTTPRoutes simultanément
+
+## Ressources
+
+- [Kubernetes Gateway API — Documentation officielle](https://gateway-api.sigs.k8s.io/)
+- [Guide de migration depuis Ingress](https://gateway-api.sigs.k8s.io/guides/migrating-from-ingress/)
+- [nginx Gateway Fabric](https://docs.nginx.com/nginx-gateway-fabric/)
+- [Envoy Gateway](https://gateway.envoyproxy.io/)
+- [Implementations disponibles](https://gateway-api.sigs.k8s.io/implementations/)

--- a/tp11/TESTS.md
+++ b/tp11/TESTS.md
@@ -1,0 +1,361 @@
+# Guide de validation du TP11 - Kubernetes Gateway API
+
+Ce document fournit un guide complet pour tester et valider tous les exercices du TP11.
+
+## Prérequis
+
+- Cluster Kubernetes ≥ 1.28
+- CRDs Gateway API installées (standard channel v1.2.1+)
+- Une implémentation active (nginx Gateway Fabric, Envoy Gateway, ou Cilium)
+- kubectl installé et configuré
+
+## Vérification de l'environnement
+
+### 1. Vérifier les CRDs Gateway API
+
+```bash
+kubectl get crd | grep gateway.networking.k8s.io
+```
+
+**✅ Attendu :** au minimum ces 5 CRDs présentes :
+```
+gatewayclasses.gateway.networking.k8s.io
+gateways.gateway.networking.k8s.io
+grpcroutes.gateway.networking.k8s.io
+httproutes.gateway.networking.k8s.io
+referencegrants.gateway.networking.k8s.io
+```
+
+### 2. Vérifier l'implémentation (nginx Gateway Fabric)
+
+```bash
+kubectl get pods -n nginx-gateway
+kubectl get gatewayclass nginx
+```
+
+**✅ Attendu :**
+- Pods `nginx-gateway-*` en `Running`
+- GatewayClass `nginx` avec `ACCEPTED: True`
+
+### 3. Préparer l'environnement
+
+```bash
+kubectl apply -f examples/01-namespace.yaml
+kubectl get namespace tp11
+```
+
+---
+
+## Tests Partie 4 : GatewayClass et Gateway
+
+### Test 4.1 : Créer la GatewayClass
+
+```bash
+kubectl apply -f examples/02-gatewayclass.yaml
+kubectl get gatewayclass nginx
+```
+
+**✅ Attendu :** `ACCEPTED: True`
+
+```bash
+# Si ACCEPTED reste False
+kubectl describe gatewayclass nginx | grep -A 5 "Conditions"
+# Vérifier que le controller est bien en cours d'exécution
+```
+
+### Test 4.2 : Créer le Gateway
+
+```bash
+kubectl apply -f examples/03-gateway.yaml
+kubectl get gateway -n tp11
+```
+
+**✅ Attendu :** `PROGRAMMED: True` et une adresse IP dans la colonne `ADDRESS`
+
+```bash
+# Récupérer l'IP pour les tests suivants
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+echo "Gateway IP: $GW_IP"
+
+# Inspecter les listeners
+kubectl describe gateway main-gateway -n tp11 | grep -A 20 "Listeners"
+```
+
+---
+
+## Tests Partie 5 : HTTPRoute basique
+
+### Test 5.1 : Déployer les backends
+
+```bash
+kubectl apply -f examples/04-backend-v1.yaml
+kubectl apply -f examples/05-backend-v2.yaml
+
+# Attendre que les pods soient prêts
+kubectl wait --for=condition=ready pod -l app=backend -n tp11 --timeout=90s
+
+# Vérifier
+kubectl get pods -n tp11
+kubectl get services -n tp11
+```
+
+**✅ Attendu :** pods `backend-v1-*` et `backend-v2-*` en `Running`
+
+### Test 5.2 : Routage par chemin
+
+```bash
+kubectl apply -f examples/06-httproute-basic.yaml
+kubectl get httproute -n tp11
+
+# Vérifier l'attachement au Gateway
+kubectl describe httproute basic-routing -n tp11 | grep -A 10 "Conditions"
+```
+
+**✅ Attendu :** `Accepted: True` et `ResolvedRefs: True`
+
+```bash
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Test chemin /api
+curl -s -H "Host: app.example.com" http://$GW_IP/api
+# ✅ Attendu : réponse de backend-v1
+
+# Test chemin /web
+curl -s -H "Host: app.example.com" http://$GW_IP/web
+# ✅ Attendu : réponse de backend-v1
+
+# Test chemin /
+curl -s -H "Host: app.example.com" http://$GW_IP/
+# ✅ Attendu : réponse de backend-v1
+```
+
+---
+
+## Tests Partie 6 : Routage avancé
+
+### Test 6.1 : Routage par header (A/B testing)
+
+```bash
+kubectl apply -f examples/07-httproute-header-routing.yaml
+
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Sans header X-Version : doit aller vers v1
+curl -s -H "Host: ab.example.com" http://$GW_IP/
+# ✅ Attendu : "v1"
+
+# Avec header X-Version: v2 : doit aller vers v2
+curl -s -H "Host: ab.example.com" -H "X-Version: v2" http://$GW_IP/
+# ✅ Attendu : "v2"
+
+# Header avec valeur différente : doit aller vers v1
+curl -s -H "Host: ab.example.com" -H "X-Version: v1" http://$GW_IP/
+# ✅ Attendu : "v1" (la règle header match uniquement "v2")
+```
+
+### Test 6.2 : Filtres — réécriture de chemin et redirection
+
+```bash
+kubectl apply -f examples/09-httproute-rewrite.yaml
+
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Test réécriture : /old-api/* doit être réécrit en /api/*
+curl -v -H "Host: rewrite.example.com" http://$GW_IP/old-api/users 2>&1 | grep -E "< HTTP|Location|v1"
+# ✅ Attendu : réponse 200, la requête est reçue sur /api/users côté backend
+
+# Test redirection
+curl -v -H "Host: rewrite.example.com" http://$GW_IP/redirect 2>&1 | grep -E "< HTTP|Location"
+# ✅ Attendu : HTTP 301, Location: https://rewrite.example.com/redirect
+```
+
+---
+
+## Tests Partie 7 : Traffic splitting
+
+### Test 7.1 : Distribution canary 90/10
+
+```bash
+kubectl apply -f examples/08-httproute-canary.yaml
+
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+echo "=== Test distribution 90/10 (30 requêtes) ==="
+for i in $(seq 1 30); do
+  curl -s -H "Host: canary.example.com" http://$GW_IP/ 2>/dev/null || echo "error"
+done | grep -o 'v[12]' | sort | uniq -c
+```
+
+**✅ Attendu :** environ 27 réponses v1, 3 réponses v2 (±3 de tolérance)
+
+### Test 7.2 : Bascule progressive
+
+```bash
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+check_distribution() {
+  local label=$1
+  echo "=== $label ==="
+  for i in $(seq 1 20); do
+    curl -s -H "Host: canary.example.com" http://$GW_IP/ 2>/dev/null
+  done | grep -o 'v[12]' | sort | uniq -c
+}
+
+# 50/50
+kubectl patch httproute canary-routing -n tp11 --type='json' \
+  -p='[{"op":"replace","path":"/spec/rules/0/backendRefs/0/weight","value":50},
+       {"op":"replace","path":"/spec/rules/0/backendRefs/1/weight","value":50}]'
+sleep 2
+check_distribution "50% v1 / 50% v2"
+
+# Bascule complète vers v2
+kubectl patch httproute canary-routing -n tp11 --type='json' \
+  -p='[{"op":"replace","path":"/spec/rules/0/backendRefs/0/weight","value":0},
+       {"op":"replace","path":"/spec/rules/0/backendRefs/1/weight","value":100}]'
+sleep 2
+check_distribution "0% v1 / 100% v2"
+
+# Rollback vers v1
+kubectl patch httproute canary-routing -n tp11 --type='json' \
+  -p='[{"op":"replace","path":"/spec/rules/0/backendRefs/0/weight","value":100},
+       {"op":"replace","path":"/spec/rules/0/backendRefs/1/weight","value":0}]'
+sleep 2
+check_distribution "Rollback : 100% v1"
+```
+
+---
+
+## Tests Partie 8 : TLS
+
+### Test 8.1 : Terminaison TLS
+
+```bash
+# Créer le certificat auto-signé
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout /tmp/tls.key -out /tmp/tls.crt \
+  -subj "/CN=secure.example.com" 2>/dev/null
+
+kubectl create secret tls tls-secret \
+  --cert=/tmp/tls.crt \
+  --key=/tmp/tls.key \
+  -n tp11 --dry-run=client -o yaml | kubectl apply -f -
+
+# Appliquer la route TLS
+kubectl apply -f examples/10-httproute-tls.yaml
+
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Tester HTTPS
+curl -k -s -H "Host: secure.example.com" https://$GW_IP/
+# ✅ Attendu : réponse de backend-v1
+
+# Vérifier le certificat
+echo | openssl s_client -connect $GW_IP:443 -servername secure.example.com 2>/dev/null | \
+  openssl x509 -noout -subject
+# ✅ Attendu : subject=CN=secure.example.com
+```
+
+---
+
+## Tests des exercices
+
+### Exercice 1 : Gateway simple
+
+```bash
+kubectl apply -f exercices/exercice-1-simple-gateway.yaml
+
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Test frontend
+RESULT=$(curl -s -H "Host: exercice1.example.com" http://$GW_IP/)
+if echo "$RESULT" | grep -q "frontend"; then
+  echo "✅ Frontend OK"
+else
+  echo "❌ Frontend KO — réponse : $RESULT"
+fi
+
+# Test API
+RESULT=$(curl -s -H "Host: exercice1.example.com" http://$GW_IP/api/)
+if echo "$RESULT" | grep -q "api"; then
+  echo "✅ API OK"
+else
+  echo "❌ API KO — réponse : $RESULT"
+fi
+```
+
+### Exercice 2 : Canary deployment
+
+```bash
+kubectl apply -f exercices/exercice-2-canary-deployment.yaml
+
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+
+# Étape 1 : tout en stable
+echo "Étape 1 — attendu : 100% stable"
+for i in $(seq 1 10); do
+  curl -s -H "Host: canary-ex.example.com" http://$GW_IP/ 2>/dev/null
+done | sort | uniq -c
+
+# ✅ Attendu : 10 "stable", 0 "canary"
+```
+
+---
+
+## Diagnostic et dépannage
+
+### Route non attachée au Gateway
+
+```bash
+kubectl describe httproute <nom-route> -n tp11 | grep -A 15 "Parents"
+```
+
+Causes fréquentes :
+- `sectionName` incorrect (ne correspond pas à un listener du Gateway)
+- Le namespace de la route n'est pas autorisé par `allowedRoutes` du Gateway
+- La GatewayClass n'est pas en `ACCEPTED: True`
+
+### Service non résolu (ResolvedRefs: False)
+
+```bash
+kubectl describe httproute <nom-route> -n tp11 | grep -A 5 "ResolvedRefs"
+```
+
+Causes fréquentes :
+- Le Service référencé n'existe pas dans le namespace
+- Le port référencé ne correspond pas au port exposé par le Service
+- Cross-namespace sans `ReferenceGrant`
+
+### Gateway non programmed
+
+```bash
+kubectl describe gateway main-gateway -n tp11 | grep -A 10 "Conditions"
+kubectl get events -n tp11 --sort-by='.lastTimestamp'
+```
+
+### Tester la connectivité réseau depuis un pod
+
+```bash
+kubectl run debug --image=registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3 \
+  --rm -it -n tp11 -- sh
+
+# Dans le pod :
+nslookup backend-v1.tp11.svc.cluster.local
+wget -qO- http://backend-v1.tp11.svc.cluster.local/
+```
+
+---
+
+## Résumé des validations
+
+| Partie | Test | Validation |
+|---|---|---|
+| 4.1 | GatewayClass | `ACCEPTED: True` |
+| 4.2 | Gateway | `PROGRAMMED: True` + IP assignée |
+| 5.2 | HTTPRoute basique | `Accepted: True` + `ResolvedRefs: True` |
+| 6.1 | Routage par header | v2 avec header, v1 sans |
+| 6.2 | URLRewrite | /old-api → /api transparent |
+| 7.1 | Traffic splitting | Distribution ≈ 90%/10% |
+| 7.2 | Bascule canary | Rollback en < 2s |
+| 8.1 | TLS | HTTPS opérationnel, CN correct |
+| Ex.1 | Exercice 1 | frontend sur /, api sur /api |
+| Ex.2 | Exercice 2 | Distribution correcte à chaque étape |

--- a/tp11/examples/01-namespace.yaml
+++ b/tp11/examples/01-namespace.yaml
@@ -1,0 +1,9 @@
+# TP11 - Namespace de travail
+# Utilisation : kubectl apply -f 01-namespace.yaml
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tp11
+  labels:
+    kubernetes.io/metadata.name: tp11

--- a/tp11/examples/02-gatewayclass.yaml
+++ b/tp11/examples/02-gatewayclass.yaml
@@ -1,0 +1,11 @@
+# GatewayClass : défini par l'infrastructure provider
+# Référence l'implémentation nginx Gateway Fabric
+# Utilisation : kubectl apply -f 02-gatewayclass.yaml
+# Vérification : kubectl get gatewayclass
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: nginx
+spec:
+  controllerName: gateway.nginx.org/nginx-gateway-controller

--- a/tp11/examples/03-gateway.yaml
+++ b/tp11/examples/03-gateway.yaml
@@ -1,0 +1,30 @@
+# Gateway : défini par l'opérateur cluster
+# Configure les listeners HTTP et HTTPS
+# Utilisation : kubectl apply -f 03-gateway.yaml
+# Vérification : kubectl get gateway -n tp11
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: main-gateway
+  namespace: tp11
+spec:
+  gatewayClassName: nginx
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+  - name: https
+    protocol: HTTPS
+    port: 443
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: tls-secret
+    allowedRoutes:
+      namespaces:
+        from: Same

--- a/tp11/examples/04-backend-v1.yaml
+++ b/tp11/examples/04-backend-v1.yaml
@@ -1,0 +1,107 @@
+# Backend v1 : application principale
+# Image nginx:alpine avec page de version personnalisée
+# Utilisation : kubectl apply -f 04-backend-v1.yaml
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-v1
+  namespace: tp11
+  labels:
+    app: backend
+    version: v1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: backend
+        version: v1
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: backend
+        image: nginx:1.27-alpine
+        ports:
+        - containerPort: 8080
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          mkdir -p /tmp/nginx /tmp/nginx/logs
+          cat > /tmp/index.html <<EOF
+          <!DOCTYPE html><html><body>
+          <h1>Backend v1</h1>
+          <p>Version: stable</p>
+          </body></html>
+          EOF
+          nginx -g 'daemon off;' -c /etc/nginx/nginx.conf
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: nginx-config
+          mountPath: /etc/nginx/conf.d
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 101
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: nginx-config
+        configMap:
+          name: nginx-config-v1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config-v1
+  namespace: tp11
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      root /tmp;
+      location / {
+        default_type text/html;
+        return 200 '<h1>Backend v1 - stable</h1>';
+      }
+      location /health {
+        return 200 'ok';
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-v1
+  namespace: tp11
+  labels:
+    app: backend
+    version: v1
+spec:
+  selector:
+    app: backend
+    version: v1
+  ports:
+  - port: 80
+    targetPort: 8080

--- a/tp11/examples/05-backend-v2.yaml
+++ b/tp11/examples/05-backend-v2.yaml
@@ -1,0 +1,94 @@
+# Backend v2 : nouvelle version (canary)
+# Utilisation : kubectl apply -f 05-backend-v2.yaml
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-v2
+  namespace: tp11
+  labels:
+    app: backend
+    version: v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: backend
+        version: v2
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: backend
+        image: nginx:1.27-alpine
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: nginx-config
+          mountPath: /etc/nginx/conf.d
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 101
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: nginx-config
+        configMap:
+          name: nginx-config-v2
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config-v2
+  namespace: tp11
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      location / {
+        default_type text/html;
+        return 200 '<h1>Backend v2 - canary</h1>';
+      }
+      location /health {
+        return 200 'ok';
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-v2
+  namespace: tp11
+  labels:
+    app: backend
+    version: v2
+spec:
+  selector:
+    app: backend
+    version: v2
+  ports:
+  - port: 80
+    targetPort: 8080

--- a/tp11/examples/06-httproute-basic.yaml
+++ b/tp11/examples/06-httproute-basic.yaml
@@ -1,0 +1,40 @@
+# HTTPRoute basique : routage par chemin (PathPrefix)
+# Défini par le développeur applicatif
+# Utilisation : kubectl apply -f 06-httproute-basic.yaml
+# Test : curl http://<GATEWAY_IP>/api
+#        curl http://<GATEWAY_IP>/web
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: basic-routing
+  namespace: tp11
+spec:
+  parentRefs:
+  - name: main-gateway
+    namespace: tp11
+    sectionName: http
+  hostnames:
+  - "app.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /api
+    backendRefs:
+    - name: backend-v1
+      port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /web
+    backendRefs:
+    - name: backend-v1
+      port: 80
+  - matches:
+    - path:
+        type: Exact
+        value: /
+    backendRefs:
+    - name: backend-v1
+      port: 80

--- a/tp11/examples/07-httproute-header-routing.yaml
+++ b/tp11/examples/07-httproute-header-routing.yaml
@@ -1,0 +1,31 @@
+# HTTPRoute avec routage par header : A/B testing
+# Les requêtes avec X-Version: v2 vont vers backend-v2
+# Les autres vont vers backend-v1
+# Utilisation : kubectl apply -f 07-httproute-header-routing.yaml
+# Test :
+#   curl -H "X-Version: v2" http://<GATEWAY_IP>/
+#   curl http://<GATEWAY_IP>/
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: header-routing
+  namespace: tp11
+spec:
+  parentRefs:
+  - name: main-gateway
+    namespace: tp11
+    sectionName: http
+  hostnames:
+  - "ab.example.com"
+  rules:
+  - matches:
+    - headers:
+      - name: X-Version
+        value: v2
+    backendRefs:
+    - name: backend-v2
+      port: 80
+  - backendRefs:
+    - name: backend-v1
+      port: 80

--- a/tp11/examples/08-httproute-canary.yaml
+++ b/tp11/examples/08-httproute-canary.yaml
@@ -1,0 +1,26 @@
+# HTTPRoute avec traffic splitting : déploiement canary
+# 90% du trafic → v1 (stable), 10% → v2 (canary)
+# Utilisation : kubectl apply -f 08-httproute-canary.yaml
+# Test :
+#   for i in $(seq 1 20); do curl -s http://<GATEWAY_IP>/ | grep -o 'v[12]'; done
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: canary-routing
+  namespace: tp11
+spec:
+  parentRefs:
+  - name: main-gateway
+    namespace: tp11
+    sectionName: http
+  hostnames:
+  - "canary.example.com"
+  rules:
+  - backendRefs:
+    - name: backend-v1
+      port: 80
+      weight: 90
+    - name: backend-v2
+      port: 80
+      weight: 10

--- a/tp11/examples/09-httproute-rewrite.yaml
+++ b/tp11/examples/09-httproute-rewrite.yaml
@@ -1,0 +1,43 @@
+# HTTPRoute avec filtres : réécriture de chemin et redirection
+# /old-api/* → /api/* (réécriture transparente)
+# /http/* → redirection 301 vers HTTPS
+# Utilisation : kubectl apply -f 09-httproute-rewrite.yaml
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rewrite-routing
+  namespace: tp11
+spec:
+  parentRefs:
+  - name: main-gateway
+    namespace: tp11
+    sectionName: http
+  hostnames:
+  - "rewrite.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /old-api
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /api
+    backendRefs:
+    - name: backend-v1
+      port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /redirect
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        statusCode: 301
+    backendRefs:
+    - name: backend-v1
+      port: 80

--- a/tp11/examples/10-httproute-tls.yaml
+++ b/tp11/examples/10-httproute-tls.yaml
@@ -1,0 +1,24 @@
+# HTTPRoute TLS : trafic HTTPS terminé au Gateway
+# Prérequis : Secret tls-secret créé au préalable
+# Créer le secret auto-signé :
+#   openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+#     -keyout tls.key -out tls.crt -subj "/CN=secure.example.com"
+#   kubectl create secret tls tls-secret --cert=tls.crt --key=tls.key -n tp11
+# Utilisation : kubectl apply -f 10-httproute-tls.yaml
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tls-routing
+  namespace: tp11
+spec:
+  parentRefs:
+  - name: main-gateway
+    namespace: tp11
+    sectionName: https
+  hostnames:
+  - "secure.example.com"
+  rules:
+  - backendRefs:
+    - name: backend-v1
+      port: 80

--- a/tp11/exercices/exercice-1-simple-gateway.yaml
+++ b/tp11/exercices/exercice-1-simple-gateway.yaml
@@ -1,0 +1,174 @@
+# Exercice 1 : Mettre en place un Gateway simple
+#
+# Objectif : Exposer deux services (frontend et api) via un seul Gateway
+# sur le même hostname avec des préfixes de chemin différents :
+#   GET /        → frontend-svc:80
+#   GET /api/*   → api-svc:80
+#
+# TODO : Compléter les sections marquées <COMPLÉTER>
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: tp11
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: frontend
+        image: nginx:1.27-alpine
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: config
+          mountPath: /etc/nginx/conf.d
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests: { cpu: 50m, memory: 64Mi }
+          limits: { cpu: 100m, memory: 128Mi }
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: config
+        configMap:
+          name: frontend-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-config
+  namespace: tp11
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      location / { return 200 'frontend'; }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-svc
+  namespace: tp11
+spec:
+  selector:
+    app: frontend
+  ports:
+  - port: 80
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: tp11
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: api
+        image: nginx:1.27-alpine
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: config
+          mountPath: /etc/nginx/conf.d
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests: { cpu: 50m, memory: 64Mi }
+          limits: { cpu: 100m, memory: 128Mi }
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: config
+        configMap:
+          name: api-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: api-config
+  namespace: tp11
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      location / { return 200 '{"service":"api","version":"1.0"}'; }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-svc
+  namespace: tp11
+spec:
+  selector:
+    app: api
+  ports:
+  - port: 80
+    targetPort: 8080
+---
+# TODO : Compléter l'HTTPRoute ci-dessous
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: exercice-1-route
+  namespace: tp11
+spec:
+  parentRefs:
+  - name: main-gateway
+    namespace: tp11
+    sectionName: http
+  hostnames:
+  - "exercice1.example.com"
+  rules:
+  # <COMPLÉTER> : règle pour /api/* → api-svc:80
+  - matches:
+    - path:
+        type: <COMPLÉTER>
+        value: <COMPLÉTER>
+    backendRefs:
+    - name: <COMPLÉTER>
+      port: <COMPLÉTER>
+  # <COMPLÉTER> : règle par défaut → frontend-svc:80
+  - backendRefs:
+    - name: <COMPLÉTER>
+      port: <COMPLÉTER>

--- a/tp11/exercices/exercice-2-canary-deployment.yaml
+++ b/tp11/exercices/exercice-2-canary-deployment.yaml
@@ -1,0 +1,176 @@
+# Exercice 2 : Canary deployment progressif
+#
+# Objectif : Simuler un déploiement canary en 3 étapes
+#   Étape 1 : 100% trafic → stable (weight: 100 / 0)
+#   Étape 2 :  20% trafic → canary, 80% → stable
+#   Étape 3 :   0% trafic → stable, basculement complet vers canary
+#
+# Modifier uniquement les weights dans l'HTTPRoute pour simuler chaque étape.
+# Vérifier avec : for i in $(seq 1 10); do curl -s http://<IP>/; done
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-stable
+  namespace: tp11
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: myapp
+      track: stable
+  template:
+    metadata:
+      labels:
+        app: myapp
+        track: stable
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: app
+        image: nginx:1.27-alpine
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: config
+          mountPath: /etc/nginx/conf.d
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests: { cpu: 50m, memory: 64Mi }
+          limits: { cpu: 100m, memory: 128Mi }
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: config
+        configMap:
+          name: stable-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stable-config
+  namespace: tp11
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      location / { return 200 'version=stable\n'; }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-stable
+  namespace: tp11
+spec:
+  selector:
+    app: myapp
+    track: stable
+  ports:
+  - port: 80
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-canary
+  namespace: tp11
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: myapp
+      track: canary
+  template:
+    metadata:
+      labels:
+        app: myapp
+        track: canary
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: app
+        image: nginx:1.27-alpine
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: config
+          mountPath: /etc/nginx/conf.d
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests: { cpu: 50m, memory: 64Mi }
+          limits: { cpu: 100m, memory: 128Mi }
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: config
+        configMap:
+          name: canary-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: canary-config
+  namespace: tp11
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      location / { return 200 'version=canary\n'; }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-canary
+  namespace: tp11
+spec:
+  selector:
+    app: myapp
+    track: canary
+  ports:
+  - port: 80
+    targetPort: 8080
+---
+# Étape 1 : 100% stable — modifier les weights pour avancer vers les étapes 2 et 3
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: exercice-2-canary
+  namespace: tp11
+spec:
+  parentRefs:
+  - name: main-gateway
+    namespace: tp11
+    sectionName: http
+  hostnames:
+  - "canary-ex.example.com"
+  rules:
+  - backendRefs:
+    - name: app-stable
+      port: 80
+      weight: 100   # Étape 1: 100 | Étape 2: 80 | Étape 3: 0
+    - name: app-canary
+      port: 80
+      weight: 0     # Étape 1: 0   | Étape 2: 20 | Étape 3: 100

--- a/tp11/test-tp11.sh
+++ b/tp11/test-tp11.sh
@@ -1,0 +1,365 @@
+#!/bin/bash
+
+# Script de test automatisé pour le TP11 - Kubernetes Gateway API
+# Usage: ./test-tp11.sh [test_name]
+# Exemples:
+#   ./test-tp11.sh                  # Exécute tous les tests
+#   ./test-tp11.sh test_gatewayclass # Exécute uniquement ce test
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_TOTAL=0
+
+NAMESPACE="tp11"
+TIMEOUT=120
+
+log()     { echo -e "${BLUE}[INFO]${NC} $1"; }
+success() { echo -e "${GREEN}[✓]${NC} $1"; ((TESTS_PASSED++)); ((TESTS_TOTAL++)); }
+error()   { echo -e "${RED}[✗]${NC} $1"; ((TESTS_FAILED++)); ((TESTS_TOTAL++)); }
+warning() { echo -e "${YELLOW}[!]${NC} $1"; }
+
+check_prerequisites() {
+    log "Vérification des prérequis..."
+
+    if ! command -v kubectl &> /dev/null; then
+        error "kubectl n'est pas installé"
+        exit 1
+    fi
+    success "kubectl installé"
+
+    if ! kubectl cluster-info &> /dev/null; then
+        error "Impossible de se connecter au cluster Kubernetes"
+        exit 1
+    fi
+    success "Connexion au cluster OK"
+
+    # Vérifier la version K8s (≥ 1.28 requis pour Gateway API v1 stable)
+    K8S_VERSION=$(kubectl version --output=json 2>/dev/null | grep -o '"gitVersion":"v[0-9]*\.[0-9]*' | head -1 | grep -o '[0-9]*\.[0-9]*$')
+    MINOR=$(echo "$K8S_VERSION" | cut -d. -f2)
+    if [ -n "$MINOR" ] && [ "$MINOR" -ge 28 ]; then
+        success "Kubernetes $K8S_VERSION (≥ 1.28 requis)"
+    else
+        warning "Kubernetes $K8S_VERSION — Gateway API v1 nécessite ≥ 1.28"
+    fi
+
+    # Vérifier les CRDs Gateway API
+    if kubectl get crd httproutes.gateway.networking.k8s.io &> /dev/null; then
+        success "CRDs Gateway API présentes"
+    else
+        error "CRDs Gateway API manquantes — installer via: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml"
+        exit 1
+    fi
+
+    # Vérifier le namespace
+    if kubectl get namespace "$NAMESPACE" &> /dev/null; then
+        success "Namespace $NAMESPACE présent"
+    else
+        warning "Namespace $NAMESPACE absent — création..."
+        kubectl create namespace "$NAMESPACE"
+        success "Namespace $NAMESPACE créé"
+    fi
+}
+
+test_gatewayclass() {
+    log "=== Test GatewayClass ==="
+
+    kubectl apply -f examples/02-gatewayclass.yaml > /dev/null 2>&1 || true
+
+    # Attendre que la GatewayClass soit acceptée
+    local retries=0
+    while [ $retries -lt 20 ]; do
+        STATUS=$(kubectl get gatewayclass nginx -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' 2>/dev/null)
+        if [ "$STATUS" = "True" ]; then
+            success "GatewayClass nginx: ACCEPTED"
+            return
+        fi
+        sleep 3
+        ((retries++))
+    done
+
+    # Si pas de GatewayClass nginx, chercher d'autres implémentations
+    OTHER=$(kubectl get gatewayclass -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    if [ -n "$OTHER" ]; then
+        warning "GatewayClass nginx non acceptée, mais '$OTHER' disponible"
+        warning "Adapter examples/02-gatewayclass.yaml ou examples/03-gateway.yaml pour utiliser '$OTHER'"
+    else
+        error "Aucune GatewayClass disponible — installer une implémentation Gateway API"
+    fi
+}
+
+test_gateway() {
+    log "=== Test Gateway ==="
+
+    kubectl apply -f examples/03-gateway.yaml > /dev/null 2>&1
+
+    log "Attente du provisionnement du Gateway (max ${TIMEOUT}s)..."
+    local retries=0
+    while [ $retries -lt $((TIMEOUT/5)) ]; do
+        STATUS=$(kubectl get gateway main-gateway -n "$NAMESPACE" \
+          -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' 2>/dev/null)
+        if [ "$STATUS" = "True" ]; then
+            success "Gateway main-gateway: PROGRAMMED"
+            break
+        fi
+        sleep 5
+        ((retries++))
+    done
+
+    if [ "$STATUS" != "True" ]; then
+        error "Gateway non programmé après ${TIMEOUT}s"
+        kubectl describe gateway main-gateway -n "$NAMESPACE" | tail -20
+        return
+    fi
+
+    GW_IP=$(kubectl get gateway main-gateway -n "$NAMESPACE" \
+      -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+    if [ -n "$GW_IP" ]; then
+        success "Gateway IP assignée: $GW_IP"
+    else
+        error "Pas d'IP assignée au Gateway"
+    fi
+}
+
+test_backends() {
+    log "=== Test déploiement des backends ==="
+
+    kubectl apply -f examples/04-backend-v1.yaml > /dev/null 2>&1
+    kubectl apply -f examples/05-backend-v2.yaml > /dev/null 2>&1
+
+    log "Attente des pods backend..."
+    if kubectl wait --for=condition=ready pod -l app=backend -n "$NAMESPACE" \
+        --timeout="${TIMEOUT}s" > /dev/null 2>&1; then
+        success "Pods backend prêts"
+    else
+        error "Pods backend non prêts après ${TIMEOUT}s"
+        kubectl get pods -n "$NAMESPACE" -l app=backend
+        return
+    fi
+
+    # Vérifier les services
+    if kubectl get service backend-v1 -n "$NAMESPACE" &> /dev/null; then
+        success "Service backend-v1 présent"
+    else
+        error "Service backend-v1 absent"
+    fi
+
+    if kubectl get service backend-v2 -n "$NAMESPACE" &> /dev/null; then
+        success "Service backend-v2 présent"
+    else
+        error "Service backend-v2 absent"
+    fi
+}
+
+test_basic_routing() {
+    log "=== Test routage basique ==="
+
+    kubectl apply -f examples/06-httproute-basic.yaml > /dev/null 2>&1
+
+    sleep 3
+
+    ACCEPTED=$(kubectl get httproute basic-routing -n "$NAMESPACE" \
+      -o jsonpath='{.status.parents[0].conditions[?(@.type=="Accepted")].status}' 2>/dev/null)
+    if [ "$ACCEPTED" = "True" ]; then
+        success "HTTPRoute basic-routing: Accepted"
+    else
+        error "HTTPRoute basic-routing non acceptée (status: $ACCEPTED)"
+    fi
+
+    RESOLVED=$(kubectl get httproute basic-routing -n "$NAMESPACE" \
+      -o jsonpath='{.status.parents[0].conditions[?(@.type=="ResolvedRefs")].status}' 2>/dev/null)
+    if [ "$RESOLVED" = "True" ]; then
+        success "HTTPRoute basic-routing: ResolvedRefs OK"
+    else
+        error "HTTPRoute basic-routing: ResolvedRefs KO (status: $RESOLVED)"
+    fi
+
+    GW_IP=$(kubectl get gateway main-gateway -n "$NAMESPACE" \
+      -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+
+    if [ -z "$GW_IP" ]; then
+        warning "IP du Gateway non disponible — tests HTTP ignorés"
+        return
+    fi
+
+    for path in "/api" "/web" "/"; do
+        RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+          -H "Host: app.example.com" "http://$GW_IP$path" 2>/dev/null)
+        if [ "$RESPONSE" = "200" ]; then
+            success "GET $path → HTTP 200"
+        else
+            error "GET $path → HTTP $RESPONSE (attendu: 200)"
+        fi
+    done
+}
+
+test_header_routing() {
+    log "=== Test routage par header ==="
+
+    kubectl apply -f examples/07-httproute-header-routing.yaml > /dev/null 2>&1
+    sleep 3
+
+    GW_IP=$(kubectl get gateway main-gateway -n "$NAMESPACE" \
+      -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+
+    if [ -z "$GW_IP" ]; then
+        warning "IP du Gateway non disponible — test ignoré"
+        return
+    fi
+
+    # Sans header → v1
+    BODY=$(curl -s -H "Host: ab.example.com" "http://$GW_IP/" 2>/dev/null)
+    if echo "$BODY" | grep -qi "v1"; then
+        success "Sans header X-Version → backend-v1"
+    else
+        warning "Sans header X-Version → réponse inattendue: $BODY"
+    fi
+
+    # Avec header X-Version: v2 → v2
+    BODY=$(curl -s -H "Host: ab.example.com" -H "X-Version: v2" "http://$GW_IP/" 2>/dev/null)
+    if echo "$BODY" | grep -qi "v2"; then
+        success "Avec X-Version: v2 → backend-v2"
+    else
+        warning "Avec X-Version: v2 → réponse inattendue: $BODY"
+    fi
+}
+
+test_canary() {
+    log "=== Test traffic splitting (canary 90/10) ==="
+
+    kubectl apply -f examples/08-httproute-canary.yaml > /dev/null 2>&1
+    sleep 3
+
+    GW_IP=$(kubectl get gateway main-gateway -n "$NAMESPACE" \
+      -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+
+    if [ -z "$GW_IP" ]; then
+        warning "IP du Gateway non disponible — test ignoré"
+        return
+    fi
+
+    local v1_count=0
+    local v2_count=0
+    local total=30
+
+    for i in $(seq 1 $total); do
+        BODY=$(curl -s -H "Host: canary.example.com" "http://$GW_IP/" 2>/dev/null)
+        if echo "$BODY" | grep -qi "v2"; then
+            ((v2_count++))
+        else
+            ((v1_count++))
+        fi
+    done
+
+    local v2_pct=$(( (v2_count * 100) / total ))
+    log "Distribution sur $total requêtes : v1=$v1_count, v2=$v2_count (v2: ${v2_pct}%)"
+
+    # Tolérance : entre 0% et 30% pour v2 (target 10%)
+    if [ "$v2_pct" -le 30 ]; then
+        success "Distribution canary cohérente (v2: ${v2_pct}%, attendu ≈10%)"
+    else
+        error "Distribution canary anormale (v2: ${v2_pct}%, attendu ≈10%)"
+    fi
+}
+
+test_tls() {
+    log "=== Test TLS ==="
+
+    if ! command -v openssl &> /dev/null; then
+        warning "openssl non disponible — test TLS ignoré"
+        return
+    fi
+
+    # Créer certificat auto-signé
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+        -keyout /tmp/tp11-tls.key -out /tmp/tp11-tls.crt \
+        -subj "/CN=secure.example.com" > /dev/null 2>&1
+
+    kubectl create secret tls tls-secret \
+        --cert=/tmp/tp11-tls.crt \
+        --key=/tmp/tp11-tls.key \
+        -n "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f - > /dev/null 2>&1
+
+    if kubectl get secret tls-secret -n "$NAMESPACE" &> /dev/null; then
+        success "Secret TLS créé"
+    else
+        error "Échec création Secret TLS"
+        return
+    fi
+
+    kubectl apply -f examples/10-httproute-tls.yaml > /dev/null 2>&1
+
+    GW_IP=$(kubectl get gateway main-gateway -n "$NAMESPACE" \
+      -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+
+    if [ -z "$GW_IP" ]; then
+        warning "IP du Gateway non disponible — test HTTPS ignoré"
+        return
+    fi
+
+    HTTPS_CODE=$(curl -k -s -o /dev/null -w "%{http_code}" \
+        -H "Host: secure.example.com" "https://$GW_IP/" 2>/dev/null)
+    if [ "$HTTPS_CODE" = "200" ]; then
+        success "HTTPS opérationnel (HTTP 200)"
+    else
+        warning "HTTPS → HTTP $HTTPS_CODE (le listener HTTPS peut nécessiter plus de temps)"
+    fi
+
+    rm -f /tmp/tp11-tls.key /tmp/tp11-tls.crt
+}
+
+print_summary() {
+    echo ""
+    echo "========================================"
+    echo "        RÉSULTATS DES TESTS TP11        "
+    echo "========================================"
+    echo -e "  Tests passés  : ${GREEN}$TESTS_PASSED${NC}"
+    echo -e "  Tests échoués : ${RED}$TESTS_FAILED${NC}"
+    echo -e "  Total         : $TESTS_TOTAL"
+    echo "========================================"
+
+    if [ "$TESTS_FAILED" -eq 0 ]; then
+        echo -e "${GREEN}✅ Tous les tests sont passés !${NC}"
+    else
+        echo -e "${RED}❌ $TESTS_FAILED test(s) en échec — voir les erreurs ci-dessus${NC}"
+        exit 1
+    fi
+}
+
+# Point d'entrée
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+check_prerequisites
+
+case "${1:-all}" in
+    test_gatewayclass)  test_gatewayclass ;;
+    test_gateway)       test_gateway ;;
+    test_backends)      test_backends ;;
+    test_basic_routing) test_basic_routing ;;
+    test_header_routing) test_header_routing ;;
+    test_canary)        test_canary ;;
+    test_tls)           test_tls ;;
+    all)
+        test_gatewayclass
+        test_gateway
+        test_backends
+        test_basic_routing
+        test_header_routing
+        test_canary
+        test_tls
+        ;;
+    *)
+        echo "Usage: $0 [test_gatewayclass|test_gateway|test_backends|test_basic_routing|test_header_routing|test_canary|test_tls|all]"
+        exit 1
+        ;;
+esac
+
+print_summary


### PR DESCRIPTION
Nouveau TP complet sur la Gateway API (GA depuis K8s 1.28) couvrant :
- Modèle de rôles : GatewayClass / Gateway / HTTPRoute
- Routage avancé : chemin, header, query params, méthode HTTP
- Traffic splitting natif pour canary deployments (weights)
- Filtres : URLRewrite, RequestRedirect, RequestHeaderModifier
- Terminaison TLS et ReferenceGrant cross-namespace
- Migration depuis Ingress avec tableau de correspondance
- 10 manifests d'exemples + 2 exercices guidés + script de test