### PR TITLE
fix(tp11): corriger cohérence et ordre du TP Gateway API

### DIFF
--- a/tp11/README.md
+++ b/tp11/README.md
@@ -236,6 +236,47 @@ kubectl apply -f examples/01-namespace.yaml
 kubectl get namespace tp11
 ```
 
+### 3.4 Récupérer l'adresse du Gateway (environnements locaux)
+
+nginx Gateway Fabric crée un Service de type `LoadBalancer`. En environnement local (minikube, kind), ce service reste en `<pending>` sans IP externe tant qu'aucun mécanisme de LoadBalancer n'est actif.
+
+**Option A — minikube tunnel (recommandé avec minikube)**
+
+Dans un **terminal séparé**, lancer et laisser tourner :
+
+```bash
+minikube tunnel
+```
+
+Puis récupérer l'IP une fois assignée :
+
+```bash
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+echo "Gateway IP: $GW_IP"
+```
+
+**Option B — NodePort via l'IP du nœud (minikube, kind)**
+
+```bash
+NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+GW_HTTP_PORT=$(kubectl get svc -n nginx-gateway \
+  -o jsonpath='{.items[0].spec.ports[?(@.port==80)].nodePort}' 2>/dev/null)
+GW_IP="${NODE_IP}:${GW_HTTP_PORT}"
+echo "Gateway accessible via: http://$GW_IP"
+```
+
+**Option C — port-forward (fonctionne dans tous les environnements)**
+
+```bash
+# Dans un terminal séparé
+kubectl port-forward svc/nginx-gateway -n nginx-gateway 8080:80 8443:443
+
+# Dans votre terminal de travail
+GW_IP="localhost:8080"
+```
+
+> **Note :** Avec l'option C, remplacer `http://$GW_IP/` par `http://$GW_IP/` dans les commandes curl — le port est déjà inclus dans la variable `GW_IP`.
+
 ---
 
 ## Partie 4 : GatewayClass et Gateway
@@ -316,9 +357,14 @@ kubectl apply -f examples/03-gateway.yaml
 # Vérifier (PROGRAMMED = infrastructure provisionnée)
 kubectl get gateway -n tp11
 kubectl describe gateway main-gateway -n tp11
+```
 
+> **Environnement local :** si la colonne `ADDRESS` est vide, consulter la [section 3.4](#34-récupérer-ladresse-du-gateway-environnements-locaux) pour activer `minikube tunnel` ou utiliser le port-forward.
+
+```bash
 # Obtenir l'IP externe du Gateway
-kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}'
+GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
+echo "Gateway IP: $GW_IP"
 ```
 
 **Exercice 4.1 :**
@@ -528,7 +574,7 @@ filters:
 ```
 
 ```bash
-kubectl apply -f examples/09-httproute-rewrite.yaml
+kubectl apply -f examples/08-httproute-rewrite.yaml
 
 GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
 
@@ -580,7 +626,7 @@ Rollback :  si anomalie, revenir à 100%/0% immédiatement
 ```
 
 ```bash
-kubectl apply -f examples/08-httproute-canary.yaml
+kubectl apply -f examples/09-httproute-canary.yaml
 
 GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
 

--- a/tp11/TESTS.md
+++ b/tp11/TESTS.md
@@ -44,6 +44,30 @@ kubectl apply -f examples/01-namespace.yaml
 kubectl get namespace tp11
 ```
 
+### 4. Récupérer l'adresse du Gateway (environnements locaux)
+
+nginx Gateway Fabric crée un Service `LoadBalancer`. En local (minikube, kind), ce service reste en `<pending>` sans mécanisme de LoadBalancer actif.
+
+**minikube — lancer dans un terminal séparé :**
+```bash
+minikube tunnel
+```
+
+**Alternative port-forward (tous environnements) :**
+```bash
+# Terminal séparé
+kubectl port-forward svc/nginx-gateway -n nginx-gateway 8080:80 8443:443
+# Puis dans les commandes : GW_IP="localhost:8080"
+```
+
+**Alternative NodePort :**
+```bash
+NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+GW_HTTP_PORT=$(kubectl get svc -n nginx-gateway \
+  -o jsonpath='{.items[0].spec.ports[?(@.port==80)].nodePort}' 2>/dev/null)
+GW_IP="${NODE_IP}:${GW_HTTP_PORT}"
+```
+
 ---
 
 ## Tests Partie 4 : GatewayClass et Gateway
@@ -156,7 +180,7 @@ curl -s -H "Host: ab.example.com" -H "X-Version: v1" http://$GW_IP/
 ### Test 6.2 : Filtres — réécriture de chemin et redirection
 
 ```bash
-kubectl apply -f examples/09-httproute-rewrite.yaml
+kubectl apply -f examples/08-httproute-rewrite.yaml
 
 GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
 
@@ -176,7 +200,7 @@ curl -v -H "Host: rewrite.example.com" http://$GW_IP/redirect 2>&1 | grep -E "< 
 ### Test 7.1 : Distribution canary 90/10
 
 ```bash
-kubectl apply -f examples/08-httproute-canary.yaml
+kubectl apply -f examples/09-httproute-canary.yaml
 
 GW_IP=$(kubectl get gateway main-gateway -n tp11 -o jsonpath='{.status.addresses[0].value}')
 

--- a/tp11/examples/04-backend-v1.yaml
+++ b/tp11/examples/04-backend-v1.yaml
@@ -33,17 +33,6 @@ spec:
         image: nginx:1.27-alpine
         ports:
         - containerPort: 8080
-        command: ["/bin/sh", "-c"]
-        args:
-        - |
-          mkdir -p /tmp/nginx /tmp/nginx/logs
-          cat > /tmp/index.html <<EOF
-          <!DOCTYPE html><html><body>
-          <h1>Backend v1</h1>
-          <p>Version: stable</p>
-          </body></html>
-          EOF
-          nginx -g 'daemon off;' -c /etc/nginx/nginx.conf
         volumeMounts:
         - name: tmp
           mountPath: /tmp
@@ -80,7 +69,6 @@ data:
   default.conf: |
     server {
       listen 8080;
-      root /tmp;
       location / {
         default_type text/html;
         return 200 '<h1>Backend v1 - stable</h1>';

--- a/tp11/examples/08-httproute-rewrite.yaml
+++ b/tp11/examples/08-httproute-rewrite.yaml
@@ -1,7 +1,7 @@
 # HTTPRoute avec filtres : réécriture de chemin et redirection
 # /old-api/* → /api/* (réécriture transparente)
 # /http/* → redirection 301 vers HTTPS
-# Utilisation : kubectl apply -f 09-httproute-rewrite.yaml
+# Utilisation : kubectl apply -f 08-httproute-rewrite.yaml
 
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -38,6 +38,3 @@ spec:
       requestRedirect:
         scheme: https
         statusCode: 301
-    backendRefs:
-    - name: backend-v1
-      port: 80

--- a/tp11/examples/09-httproute-canary.yaml
+++ b/tp11/examples/09-httproute-canary.yaml
@@ -1,6 +1,6 @@
 # HTTPRoute avec traffic splitting : déploiement canary
 # 90% du trafic → v1 (stable), 10% → v2 (canary)
-# Utilisation : kubectl apply -f 08-httproute-canary.yaml
+# Utilisation : kubectl apply -f 09-httproute-canary.yaml
 # Test :
 #   for i in $(seq 1 20); do curl -s http://<GATEWAY_IP>/ | grep -o 'v[12]'; done
 

--- a/tp11/exercices/exercice-3-cross-namespace.yaml
+++ b/tp11/exercices/exercice-3-cross-namespace.yaml
@@ -1,0 +1,129 @@
+# Exercice 3 : HTTPRoute cross-namespace avec ReferenceGrant
+#
+# Objectif : Permettre à une HTTPRoute dans le namespace "team-a" de cibler
+# un Service dans le namespace "shared-services", via un ReferenceGrant explicite.
+#
+# Architecture :
+#   [Gateway - tp11] ← [HTTPRoute - team-a] → [Service - shared-services]
+#                                                     ↑
+#                                           ReferenceGrant requis ici
+#
+# Étapes :
+#   1. Créer les namespaces : kubectl create namespace team-a shared-services
+#   2. Appliquer ce fichier : kubectl apply -f exercice-3-cross-namespace.yaml
+#   3. Vérifier l'attachement de la route (ResolvedRefs doit être True)
+#   4. Supprimer le ReferenceGrant et observer l'effet sur la route
+#
+# Question 1 : Que se passe-t-il si vous appliquez l'HTTPRoute sans le ReferenceGrant ?
+# Question 2 : À quoi sert le champ "name" dans spec.to du ReferenceGrant ?
+#              Que se passe-t-il si vous le supprimez (accès à tous les Secrets/Services) ?
+
+---
+# Service partagé dans shared-services
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shared-api
+  namespace: shared-services
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: shared-api
+  template:
+    metadata:
+      labels:
+        app: shared-api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: api
+        image: nginx:1.27-alpine
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: config
+          mountPath: /etc/nginx/conf.d
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests: { cpu: 50m, memory: 64Mi }
+          limits: { cpu: 100m, memory: 128Mi }
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: config
+        configMap:
+          name: shared-api-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shared-api-config
+  namespace: shared-services
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      location / { return 200 '{"service":"shared-api","namespace":"shared-services"}'; }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shared-api
+  namespace: shared-services
+spec:
+  selector:
+    app: shared-api
+  ports:
+  - port: 80
+    targetPort: 8080
+---
+# ReferenceGrant : placé dans shared-services, autorise team-a à cibler shared-api
+# Sans ce manifest, l'HTTPRoute ci-dessous aura ResolvedRefs: False
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-team-a
+  namespace: shared-services    # Namespace du Service cible
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: team-a           # Seul team-a est autorisé
+  to:
+  - group: ""
+    kind: Service
+    name: shared-api            # Seul ce Service est exposé (granularité fine)
+---
+# HTTPRoute dans team-a qui cible le service cross-namespace
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cross-namespace-route
+  namespace: team-a
+spec:
+  parentRefs:
+  - name: main-gateway
+    namespace: tp11             # Gateway dans tp11
+  hostnames:
+  - "shared.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /shared
+    backendRefs:
+    - name: shared-api
+      namespace: shared-services   # Cross-namespace : nécessite le ReferenceGrant
+      port: 80

--- a/tp11/test-tp11.sh
+++ b/tp11/test-tp11.sh
@@ -21,6 +21,35 @@ TESTS_TOTAL=0
 NAMESPACE="tp11"
 TIMEOUT=120
 
+# Récupère l'IP du Gateway avec fallback NodePort si LoadBalancer non disponible
+get_gw_ip() {
+    local gw_ip
+    gw_ip=$(kubectl get gateway main-gateway -n "$NAMESPACE" \
+        -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+
+    if [ -z "$gw_ip" ]; then
+        # Fallback : NodeIP + NodePort du service nginx-gateway
+        local node_ip node_port
+        node_ip=$(kubectl get nodes \
+            -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null)
+        node_port=$(kubectl get svc -n nginx-gateway \
+            -o jsonpath='{.items[0].spec.ports[?(@.port==80)].nodePort}' 2>/dev/null)
+
+        if [ -n "$node_ip" ] && [ -n "$node_port" ]; then
+            gw_ip="${node_ip}:${node_port}"
+            warning "LoadBalancer IP non disponible — utilisation du NodePort: $gw_ip"
+            warning "Pour minikube : lancer 'minikube tunnel' dans un terminal séparé"
+        else
+            warning "IP du Gateway non disponible."
+            warning "Solutions :"
+            warning "  - minikube : lancer 'minikube tunnel' dans un terminal séparé"
+            warning "  - Tous clusters : kubectl port-forward svc/nginx-gateway -n nginx-gateway 8080:80"
+        fi
+    fi
+
+    echo "$gw_ip"
+}
+
 log()     { echo -e "${BLUE}[INFO]${NC} $1"; }
 success() { echo -e "${GREEN}[✓]${NC} $1"; ((TESTS_PASSED++)); ((TESTS_TOTAL++)); }
 error()   { echo -e "${RED}[✗]${NC} $1"; ((TESTS_FAILED++)); ((TESTS_TOTAL++)); }
@@ -119,12 +148,12 @@ test_gateway() {
         return
     fi
 
-    GW_IP=$(kubectl get gateway main-gateway -n "$NAMESPACE" \
-      -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+    GW_IP=$(get_gw_ip)
     if [ -n "$GW_IP" ]; then
-        success "Gateway IP assignée: $GW_IP"
+        success "Gateway accessible: $GW_IP"
     else
-        error "Pas d'IP assignée au Gateway"
+        warning "Pas d'IP assignée au Gateway — les tests HTTP seront ignorés"
+        warning "Lancer 'minikube tunnel' ou 'kubectl port-forward svc/nginx-gateway -n nginx-gateway 8080:80'"
     fi
 }
 
@@ -181,8 +210,7 @@ test_basic_routing() {
         error "HTTPRoute basic-routing: ResolvedRefs KO (status: $RESOLVED)"
     fi
 
-    GW_IP=$(kubectl get gateway main-gateway -n "$NAMESPACE" \
-      -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+    GW_IP=$(get_gw_ip)
 
     if [ -z "$GW_IP" ]; then
         warning "IP du Gateway non disponible — tests HTTP ignorés"
@@ -206,8 +234,7 @@ test_header_routing() {
     kubectl apply -f examples/07-httproute-header-routing.yaml > /dev/null 2>&1
     sleep 3
 
-    GW_IP=$(kubectl get gateway main-gateway -n "$NAMESPACE" \
-      -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+    GW_IP=$(get_gw_ip)
 
     if [ -z "$GW_IP" ]; then
         warning "IP du Gateway non disponible — test ignoré"
@@ -231,14 +258,53 @@ test_header_routing() {
     fi
 }
 
+test_rewrite() {
+    log "=== Test filtres (réécriture et redirection) ==="
+
+    kubectl apply -f examples/08-httproute-rewrite.yaml > /dev/null 2>&1
+    sleep 3
+
+    ACCEPTED=$(kubectl get httproute rewrite-routing -n "$NAMESPACE" \
+      -o jsonpath='{.status.parents[0].conditions[?(@.type=="Accepted")].status}' 2>/dev/null)
+    if [ "$ACCEPTED" = "True" ]; then
+        success "HTTPRoute rewrite-routing: Accepted"
+    else
+        error "HTTPRoute rewrite-routing non acceptée (status: $ACCEPTED)"
+    fi
+
+    GW_IP=$(get_gw_ip)
+
+    if [ -z "$GW_IP" ]; then
+        warning "IP du Gateway non disponible — tests HTTP ignorés"
+        return
+    fi
+
+    # Test réécriture /old-api → /api (doit retourner 200)
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+        -H "Host: rewrite.example.com" "http://$GW_IP/old-api/users" 2>/dev/null)
+    if [ "$HTTP_CODE" = "200" ]; then
+        success "URLRewrite /old-api → /api : HTTP 200"
+    else
+        error "URLRewrite /old-api → /api : HTTP $HTTP_CODE (attendu: 200)"
+    fi
+
+    # Test redirection /redirect → 301
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+        -H "Host: rewrite.example.com" "http://$GW_IP/redirect" 2>/dev/null)
+    if [ "$HTTP_CODE" = "301" ]; then
+        success "RequestRedirect /redirect : HTTP 301"
+    else
+        error "RequestRedirect /redirect : HTTP $HTTP_CODE (attendu: 301)"
+    fi
+}
+
 test_canary() {
     log "=== Test traffic splitting (canary 90/10) ==="
 
-    kubectl apply -f examples/08-httproute-canary.yaml > /dev/null 2>&1
+    kubectl apply -f examples/09-httproute-canary.yaml > /dev/null 2>&1
     sleep 3
 
-    GW_IP=$(kubectl get gateway main-gateway -n "$NAMESPACE" \
-      -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+    GW_IP=$(get_gw_ip)
 
     if [ -z "$GW_IP" ]; then
         warning "IP du Gateway non disponible — test ignoré"
@@ -296,8 +362,7 @@ test_tls() {
 
     kubectl apply -f examples/10-httproute-tls.yaml > /dev/null 2>&1
 
-    GW_IP=$(kubectl get gateway main-gateway -n "$NAMESPACE" \
-      -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+    GW_IP=$(get_gw_ip)
 
     if [ -z "$GW_IP" ]; then
         warning "IP du Gateway non disponible — test HTTPS ignoré"
@@ -340,24 +405,26 @@ cd "$SCRIPT_DIR"
 check_prerequisites
 
 case "${1:-all}" in
-    test_gatewayclass)  test_gatewayclass ;;
-    test_gateway)       test_gateway ;;
-    test_backends)      test_backends ;;
-    test_basic_routing) test_basic_routing ;;
+    test_gatewayclass)   test_gatewayclass ;;
+    test_gateway)        test_gateway ;;
+    test_backends)       test_backends ;;
+    test_basic_routing)  test_basic_routing ;;
     test_header_routing) test_header_routing ;;
-    test_canary)        test_canary ;;
-    test_tls)           test_tls ;;
+    test_rewrite)        test_rewrite ;;
+    test_canary)         test_canary ;;
+    test_tls)            test_tls ;;
     all)
         test_gatewayclass
         test_gateway
         test_backends
         test_basic_routing
         test_header_routing
+        test_rewrite
         test_canary
         test_tls
         ;;
     *)
-        echo "Usage: $0 [test_gatewayclass|test_gateway|test_backends|test_basic_routing|test_header_routing|test_canary|test_tls|all]"
+        echo "Usage: $0 [test_gatewayclass|test_gateway|test_backends|test_basic_routing|test_header_routing|test_rewrite|test_canary|test_tls|all]"
         exit 1
         ;;
 esac


### PR DESCRIPTION
- Inverser les numéros 08/09 : rewrite (06→partie 6) précède canary (partie 7)
- Ajouter test_rewrite() dans test-tp11.sh pour couvrir 08-httproute-rewrite.yaml
- Créer exercice-3-cross-namespace.yaml (ReferenceGrant + HTTPRoute cross-ns)
- Supprimer root /tmp inutile et index.html dans 04-backend-v1.yaml
- Retirer backendRefs superflu de la règle RequestRedirect dans 08-httproute-rewrite.yaml
- Ajouter section 3.4 : obtenir l'IP du Gateway en environnement local (minikube tunnel, NodePort, port-forward) dans README et TESTS.md
- Ajouter get_gw_ip() avec fallback NodePort dans test-tp11.sh