### PR TITLE
fix(tp11): corriger readOnlyRootFilesystem pour nginx — ajouter volum…

### DIFF
--- a/tp11/examples/04-backend-v1.yaml
+++ b/tp11/examples/04-backend-v1.yaml
@@ -36,8 +36,13 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
         - name: nginx-config
           mountPath: /etc/nginx/conf.d
+          readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -55,6 +60,10 @@ spec:
             memory: 128Mi
       volumes:
       - name: tmp
+        emptyDir: {}
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
         emptyDir: {}
       - name: nginx-config
         configMap:

--- a/tp11/examples/05-backend-v2.yaml
+++ b/tp11/examples/05-backend-v2.yaml
@@ -35,8 +35,13 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
         - name: nginx-config
           mountPath: /etc/nginx/conf.d
+          readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -54,6 +59,10 @@ spec:
             memory: 128Mi
       volumes:
       - name: tmp
+        emptyDir: {}
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
         emptyDir: {}
       - name: nginx-config
         configMap:

--- a/tp11/exercices/exercice-1-simple-gateway.yaml
+++ b/tp11/exercices/exercice-1-simple-gateway.yaml
@@ -36,8 +36,13 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
         - name: config
           mountPath: /etc/nginx/conf.d
+          readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -48,6 +53,10 @@ spec:
           limits: { cpu: 100m, memory: 128Mi }
       volumes:
       - name: tmp
+        emptyDir: {}
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
         emptyDir: {}
       - name: config
         configMap:
@@ -105,8 +114,13 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
         - name: config
           mountPath: /etc/nginx/conf.d
+          readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -117,6 +131,10 @@ spec:
           limits: { cpu: 100m, memory: 128Mi }
       volumes:
       - name: tmp
+        emptyDir: {}
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
         emptyDir: {}
       - name: config
         configMap:

--- a/tp11/exercices/exercice-2-canary-deployment.yaml
+++ b/tp11/exercices/exercice-2-canary-deployment.yaml
@@ -39,8 +39,13 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
         - name: config
           mountPath: /etc/nginx/conf.d
+          readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -51,6 +56,10 @@ spec:
           limits: { cpu: 100m, memory: 128Mi }
       volumes:
       - name: tmp
+        emptyDir: {}
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
         emptyDir: {}
       - name: config
         configMap:
@@ -111,8 +120,13 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
         - name: config
           mountPath: /etc/nginx/conf.d
+          readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -123,6 +137,10 @@ spec:
           limits: { cpu: 100m, memory: 128Mi }
       volumes:
       - name: tmp
+        emptyDir: {}
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
         emptyDir: {}
       - name: config
         configMap:

--- a/tp11/exercices/exercice-3-cross-namespace.yaml
+++ b/tp11/exercices/exercice-3-cross-namespace.yaml
@@ -48,8 +48,13 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
         - name: config
           mountPath: /etc/nginx/conf.d
+          readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -60,6 +65,10 @@ spec:
           limits: { cpu: 100m, memory: 128Mi }
       volumes:
       - name: tmp
+        emptyDir: {}
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
         emptyDir: {}
       - name: config
         configMap:


### PR DESCRIPTION
…es manquants

nginx:alpine écrit son PID dans /var/run/nginx.pid et ses fichiers temporaires dans /var/cache/nginx/. Sans volumes inscriptibles sur ces chemins, les pods crashent au démarrage avec "Read-only file system" malgré un securityContext valide.

- Ajouter emptyDir nginx-cache (/var/cache/nginx) et nginx-run (/var/run) sur tous les Deployments nginx du TP11 (examples + exercices)
- Marquer les ConfigMaps montés readOnly: true

Fichiers corrigés : 04-backend-v1, 05-backend-v2, exercice-1, exercice-2, exercice-3