### PR TITLE
feat(tp04): compléter la pile EFK — Elasticsearch, Kibana et Fluentd …

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,7 @@
+# Suppressions Trivy justifiées
+#
+# AVD-KSV-0125 — Registre non approuvé par défaut
+# docker.elastic.co est le registre officiel d'Elastic pour Elasticsearch et Kibana.
+# Il n'existe pas d'image équivalente sur Docker Hub ou d'autre registre "approuvé".
+# Référence : https://www.docker.elastic.co
+AVD-KSV-0125

--- a/tp04/08-fluentd-daemonset.yaml
+++ b/tp04/08-fluentd-daemonset.yaml
@@ -1,3 +1,11 @@
+# Fluentd — collecte des logs de tous les containers et envoi vers Elasticsearch
+# Prérequis : 09-elasticsearch.yaml appliqué et Elasticsearch prêt
+# Utilisation :
+#   kubectl apply -f 08-fluentd-daemonset.yaml
+#   kubectl get daemonset fluentd -n kube-system
+#   kubectl get pods -n kube-system -l app=fluentd
+
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,6 +13,7 @@ metadata:
   namespace: kube-system
 data:
   fluent.conf: |
+    # Source : collecte les logs de tous les containers via les fichiers du nœud
     <source>
       @type tail
       path /var/log/containers/*.log
@@ -17,13 +26,32 @@ data:
       </parse>
     </source>
 
+    # Filtre : enrichit chaque log avec les métadonnées Kubernetes (pod, namespace, labels)
     <filter kubernetes.**>
       @type kubernetes_metadata
       @id filter_kube_metadata
     </filter>
 
+    # Sortie : envoie vers Elasticsearch
     <match kubernetes.**>
-      @type stdout
+      @type elasticsearch
+      host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
+      port "#{ENV['FLUENT_ELASTICSEARCH_PORT']}"
+      scheme http
+      index_name fluentd-${tag}-%Y%m%d
+      type_name _doc
+      include_timestamp true
+      <buffer tag,time>
+        @type file
+        path /var/log/fluentd-buffers/kubernetes.buffer
+        flush_mode interval
+        retry_type exponential_backoff
+        flush_interval 5s
+        retry_max_interval 30
+        chunk_limit_size 2M
+        queue_limit_length 8
+        overflow_action block
+      </buffer>
     </match>
 ---
 apiVersion: v1
@@ -77,12 +105,26 @@ spec:
         app: fluentd
     spec:
       serviceAccountName: fluentd
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
       containers:
       - name: fluentd
-        image: fluent/fluentd-kubernetes-daemonset:v1.16-debian-1
+        image: fluent/fluentd-kubernetes-daemonset:v1.19-debian-elasticsearch8-amd64-1
         env:
         - name: FLUENTD_SYSTEMD_CONF
           value: "disable"
+        - name: FLUENT_ELASTICSEARCH_HOST
+          value: "elasticsearch.logging.svc.cluster.local"
+        - name: FLUENT_ELASTICSEARCH_PORT
+          value: "9200"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 200m
+            memory: 400Mi
         volumeMounts:
         - name: fluentd-config
           mountPath: /fluentd/etc/fluent.conf
@@ -92,12 +134,6 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
-        resources:
-          limits:
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 200Mi
       volumes:
       - name: fluentd-config
         configMap:

--- a/tp04/09-elasticsearch.yaml
+++ b/tp04/09-elasticsearch.yaml
@@ -1,6 +1,12 @@
 # Elasticsearch — nœud unique pour le TP
 # Namespace dédié : logging
 # Sécurité xpack désactivée pour simplifier le TP (ne pas faire en production)
+#
+# Prérequis : vm.max_map_count ≥ 262144 sur chaque nœud (voir README section 8.2)
+#   minikube : minikube ssh -- 'sudo sysctl -w vm.max_map_count=262144'
+#   kind     : docker exec -it <node> sysctl -w vm.max_map_count=262144
+#   kubeadm  : sudo sysctl -w vm.max_map_count=262144 (sur chaque nœud)
+#
 # Utilisation :
 #   kubectl apply -f 09-elasticsearch.yaml
 #   kubectl wait --for=condition=ready pod -l app=elasticsearch -n logging --timeout=120s
@@ -53,17 +59,10 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+        runAsNonRoot: true
         fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
-      initContainers:
-      # Elasticsearch nécessite vm.max_map_count ≥ 262144
-      - name: sysctl
-        image: busybox:1.37
-        command: ["sysctl", "-w", "vm.max_map_count=262144"]
-        securityContext:
-          privileged: true
-          runAsUser: 0
       containers:
       - name: elasticsearch
         image: docker.elastic.co/elasticsearch/elasticsearch:8.17.7
@@ -81,6 +80,14 @@ spec:
           value: "-Xms512m -Xmx512m"
         - name: cluster.name
           value: tp04-logging
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         resources:
           requests:
             cpu: 500m
@@ -105,6 +112,14 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /usr/share/elasticsearch/data
+        - name: logs
+          mountPath: /usr/share/elasticsearch/logs
+        - name: tmp
+          mountPath: /tmp
       volumes:
       - name: data
+        emptyDir: {}
+      - name: logs
+        emptyDir: {}
+      - name: tmp
         emptyDir: {}

--- a/tp04/09-elasticsearch.yaml
+++ b/tp04/09-elasticsearch.yaml
@@ -1,0 +1,110 @@
+# Elasticsearch — nœud unique pour le TP
+# Namespace dédié : logging
+# Sécurité xpack désactivée pour simplifier le TP (ne pas faire en production)
+# Utilisation :
+#   kubectl apply -f 09-elasticsearch.yaml
+#   kubectl wait --for=condition=ready pod -l app=elasticsearch -n logging --timeout=120s
+#   kubectl port-forward svc/elasticsearch 9200:9200 -n logging
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging
+  labels:
+    kubernetes.io/metadata.name: logging
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: logging
+  labels:
+    app: elasticsearch
+spec:
+  selector:
+    app: elasticsearch
+  ports:
+  - name: http
+    port: 9200
+    targetPort: 9200
+  - name: transport
+    port: 9300
+    targetPort: 9300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+  namespace: logging
+  labels:
+    app: elasticsearch
+spec:
+  serviceName: elasticsearch
+  replicas: 1
+  selector:
+    matchLabels:
+      app: elasticsearch
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+      # Elasticsearch nécessite vm.max_map_count ≥ 262144
+      - name: sysctl
+        image: busybox:1.37
+        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        securityContext:
+          privileged: true
+          runAsUser: 0
+      containers:
+      - name: elasticsearch
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.17.7
+        ports:
+        - containerPort: 9200
+          name: http
+        - containerPort: 9300
+          name: transport
+        env:
+        - name: discovery.type
+          value: single-node
+        - name: xpack.security.enabled
+          value: "false"
+        - name: ES_JAVA_OPTS
+          value: "-Xms512m -Xmx512m"
+        - name: cluster.name
+          value: tp04-logging
+        resources:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: 1
+            memory: 2Gi
+        readinessProbe:
+          httpGet:
+            path: /_cluster/health
+            port: 9200
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 6
+        livenessProbe:
+          httpGet:
+            path: /_cluster/health
+            port: 9200
+          initialDelaySeconds: 60
+          periodSeconds: 20
+          failureThreshold: 3
+        volumeMounts:
+        - name: data
+          mountPath: /usr/share/elasticsearch/data
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/tp04/10-kibana.yaml
+++ b/tp04/10-kibana.yaml
@@ -27,6 +27,7 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+        runAsNonRoot: true
         fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
@@ -43,6 +44,14 @@ spec:
           value: kibana
         - name: XPACK_SECURITY_ENABLED
           value: "false"
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         resources:
           requests:
             cpu: 250m
@@ -64,6 +73,16 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 20
           failureThreshold: 3
+        volumeMounts:
+        - name: data
+          mountPath: /usr/share/kibana/data
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: data
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/tp04/10-kibana.yaml
+++ b/tp04/10-kibana.yaml
@@ -1,0 +1,81 @@
+# Kibana — interface de visualisation des logs
+# Prérequis : 09-elasticsearch.yaml appliqué et Elasticsearch prêt
+# Utilisation :
+#   kubectl apply -f 10-kibana.yaml
+#   kubectl wait --for=condition=ready pod -l app=kibana -n logging --timeout=120s
+#   kubectl port-forward svc/kibana 5601:5601 -n logging
+#   Ouvrir : http://localhost:5601
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kibana
+  namespace: logging
+  labels:
+    app: kibana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kibana
+  template:
+    metadata:
+      labels:
+        app: kibana
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: kibana
+        image: docker.elastic.co/kibana/kibana:8.17.7
+        ports:
+        - containerPort: 5601
+          name: http
+        env:
+        - name: ELASTICSEARCH_HOSTS
+          value: "http://elasticsearch.logging.svc.cluster.local:9200"
+        - name: SERVER_NAME
+          value: kibana
+        - name: XPACK_SECURITY_ENABLED
+          value: "false"
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            path: /api/status
+            port: 5601
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 6
+        livenessProbe:
+          httpGet:
+            path: /api/status
+            port: 5601
+          initialDelaySeconds: 60
+          periodSeconds: 20
+          failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana
+  namespace: logging
+  labels:
+    app: kibana
+spec:
+  selector:
+    app: kibana
+  ports:
+  - name: http
+    port: 5601
+    targetPort: 5601

--- a/tp04/README.md
+++ b/tp04/README.md
@@ -1365,170 +1365,180 @@ Dans l'interface Prometheus :
 2. Vous verrez les règles d'alerte configurées
 3. Les alertes actives apparaîtront en rouge
 
-## Partie 8 : Logging avancé (Introduction)
+## Partie 8 : Logging avancé — Stack EFK complète
 
-### 8.1 Stack EFK/ELK
+### 8.1 Architecture EFK
 
-Pour une gestion avancée des logs, on utilise généralement :
+La stack EFK centralise les logs de tous les pods du cluster dans une interface unique :
 
-**Stack EFK** :
-- **E**lasticsearch : Stockage et indexation des logs
-- **F**luentd/Fluent Bit : Collecte et agrégation des logs
-- **K**ibana : Visualisation
-
-**Stack ELK** :
-- **E**lasticsearch
-- **L**ogstash : Collecte et transformation
-- **K**ibana
-
-### 8.2 Introduction à Fluentd
-
-**Note importante** : Cette section présente une configuration simplifiée de Fluentd pour la démonstration. Pour une installation complète d'EFK avec Elasticsearch et Kibana, consultez les ressources complémentaires en fin de TP.
-
-Dans cet exercice, nous déployons Fluentd avec une sortie vers stdout pour observer la collecte des logs.
-
-Créer `08-fluentd-daemonset.yaml` :
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluentd-config
-  namespace: kube-system
-data:
-  fluent.conf: |
-    <source>
-      @type tail
-      path /var/log/containers/*.log
-      pos_file /var/log/fluentd-containers.log.pos
-      tag kubernetes.*
-      read_from_head true
-      <parse>
-        @type json
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
-      </parse>
-    </source>
-
-    <filter kubernetes.**>
-      @type kubernetes_metadata
-      @id filter_kube_metadata
-    </filter>
-
-    <match kubernetes.**>
-      @type stdout
-    </match>
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: fluentd
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: fluentd
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: fluentd
-roleRef:
-  kind: ClusterRole
-  name: fluentd
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: fluentd
-  namespace: kube-system
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluentd
-  namespace: kube-system
-  labels:
-    app: fluentd
-spec:
-  selector:
-    matchLabels:
-      app: fluentd
-  template:
-    metadata:
-      labels:
-        app: fluentd
-    spec:
-      serviceAccountName: fluentd
-      containers:
-      - name: fluentd
-        image: fluent/fluentd-kubernetes-daemonset:v1.16-debian-1
-        env:
-        - name: FLUENTD_SYSTEMD_CONF
-          value: "disable"
-        volumeMounts:
-        - name: fluentd-config
-          mountPath: /fluentd/etc/fluent.conf
-          subPath: fluent.conf
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        resources:
-          limits:
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 200Mi
-      volumes:
-      - name: fluentd-config
-        configMap:
-          name: fluentd-config
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
+```
+┌─────────────────────────────────────────────────────────┐
+│  Chaque nœud                                            │
+│  ┌──────────┐   /var/log/containers/*.log               │
+│  │  Fluentd │──────────────────────────────────────┐    │
+│  │ DaemonSet│  collecte + enrichissement metadata  │    │
+│  └──────────┘                                      │    │
+└────────────────────────────────────────────────────┼────┘
+                                                     │
+                                                     ▼
+                                    ┌─────────────────────────┐
+                                    │  Elasticsearch          │
+                                    │  namespace: logging     │
+                                    │  stockage + indexation  │
+                                    └────────────┬────────────┘
+                                                 │
+                                                 ▼
+                                    ┌─────────────────────────┐
+                                    │  Kibana                 │
+                                    │  namespace: logging     │
+                                    │  visualisation + search │
+                                    └─────────────────────────┘
 ```
 
-**Exercice 14 : Déployer Fluentd**
+**Composants** :
+- **Elasticsearch** : base de données orientée document, indexe et stocke les logs
+- **Fluentd** : agent de collecte déployé en DaemonSet (un pod par nœud), lit les fichiers de logs et les envoie vers Elasticsearch enrichis de métadonnées Kubernetes (pod, namespace, labels)
+- **Kibana** : interface web pour explorer, filtrer et visualiser les logs
+
+> **Note** : `xpack.security` est désactivé dans cette configuration pour simplifier le TP. En production, activer l'authentification et le chiffrement TLS.
+
+---
+
+### 8.2 Déployer Elasticsearch
+
+**Exercice 14 : Déployer Elasticsearch**
 
 ```bash
-# Déployer Fluentd
-kubectl apply -f 08-fluentd-daemonset.yaml
+kubectl apply -f 09-elasticsearch.yaml
 
-# Vérifier le DaemonSet
-kubectl get daemonset fluentd -n kube-system
+# Attendre que le pod soit prêt (l'initialisation prend ~60s)
+kubectl wait --for=condition=ready pod -l app=elasticsearch -n logging --timeout=120s
 
-# Vérifier les pods Fluentd (un par nœud)
-kubectl get pods -n kube-system -l app=fluentd
+# Vérifier l'état du cluster
+kubectl get statefulset elasticsearch -n logging
+kubectl get pods -n logging -l app=elasticsearch
 
-# Voir les logs collectés par Fluentd
-FLUENTD_POD=$(kubectl get pods -n kube-system -l app=fluentd -o jsonpath='{.items[0].metadata.name}')
-kubectl logs -n kube-system $FLUENTD_POD --tail=50
-
-# Observer les logs en temps réel
-kubectl logs -n kube-system $FLUENTD_POD -f
+# Tester l'API Elasticsearch depuis le cluster
+kubectl run curl-test --image=curlimages/curl:8.11.1 --rm -it --restart=Never -- \
+  curl -s http://elasticsearch.logging.svc.cluster.local:9200/_cluster/health | head -c 200
 ```
 
-**Note** : Cette configuration affiche simplement les logs collectés vers stdout. Pour une installation complète avec Elasticsearch et Kibana, consultez les ressources complémentaires ci-dessous.
+**✅ Attendu :** `"status":"green"` ou `"status":"yellow"` (nœud unique → yellow est normal)
 
-**Pour aller plus loin avec EFK** :
-- Déployer Elasticsearch avec l'Elastic Cloud on Kubernetes (ECK) operator
-- Configurer Kibana pour la visualisation
-- Modifier la configuration Fluentd pour envoyer vers Elasticsearch
-- Voir : [Elastic Cloud on Kubernetes](https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html)
+```bash
+# Accès local via port-forward
+kubectl port-forward svc/elasticsearch 9200:9200 -n logging &
+curl http://localhost:9200/_cluster/health?pretty
+```
+
+---
+
+### 8.3 Déployer Kibana
+
+**Exercice 15 : Déployer Kibana**
+
+```bash
+kubectl apply -f 10-kibana.yaml
+
+# Attendre que le pod soit prêt (l'initialisation prend ~60s)
+kubectl wait --for=condition=ready pod -l app=kibana -n logging --timeout=120s
+
+# Vérifier
+kubectl get deployment kibana -n logging
+kubectl get pods -n logging -l app=kibana
+```
+
+```bash
+# Accès à l'interface Kibana
+kubectl port-forward svc/kibana 5601:5601 -n logging
+# Ouvrir http://localhost:5601 dans un navigateur
+```
+
+---
+
+### 8.4 Déployer Fluentd (connecté à Elasticsearch)
+
+**Exercice 16 : Déployer Fluentd**
+
+```bash
+kubectl apply -f 08-fluentd-daemonset.yaml
+
+# Vérifier le DaemonSet (un pod par nœud)
+kubectl get daemonset fluentd -n kube-system
+kubectl get pods -n kube-system -l app=fluentd
+
+# Vérifier que Fluentd envoie bien vers Elasticsearch (pas d'erreurs)
+FLUENTD_POD=$(kubectl get pods -n kube-system -l app=fluentd -o jsonpath='{.items[0].metadata.name}')
+kubectl logs -n kube-system $FLUENTD_POD --tail=30
+
+# Vérifier les index créés dans Elasticsearch
+kubectl run curl-test --image=curlimages/curl:8.11.1 --rm -it --restart=Never -- \
+  curl -s http://elasticsearch.logging.svc.cluster.local:9200/_cat/indices?v
+```
+
+**✅ Attendu :** des index `fluentd-kubernetes.*-YYYYMMDD` apparaissent après quelques secondes.
+
+**Erreurs fréquentes :**
+
+```bash
+# Si Fluentd ne peut pas joindre Elasticsearch
+kubectl describe pod $FLUENTD_POD -n kube-system | grep -A 5 "Events"
+
+# Vérifier la résolution DNS depuis kube-system
+kubectl run dns-test --image=busybox:1.37 --rm -it --restart=Never -n kube-system -- \
+  nslookup elasticsearch.logging.svc.cluster.local
+```
+
+---
+
+### 8.5 Vérifier le pipeline et explorer dans Kibana
+
+**Exercice 17 : Explorer les logs dans Kibana**
+
+```bash
+# Accéder à Kibana
+kubectl port-forward svc/kibana 5601:5601 -n logging
+```
+
+Dans Kibana (`http://localhost:5601`) :
+
+1. **Créer un Data View** : menu ☰ → *Management* → *Data Views* → *Create data view*
+   - Name : `fluentd-kubernetes`
+   - Index pattern : `fluentd-kubernetes.*`
+   - Timestamp field : `@timestamp`
+   - Cliquer *Save data view to Kibana*
+
+2. **Explorer les logs** : menu ☰ → *Discover*
+   - Sélectionner le Data View `fluentd-kubernetes`
+   - Filtrer par namespace : chercher `kubernetes.namespace_name : default`
+   - Filtrer par pod : `kubernetes.pod_name : <nom-du-pod>`
+
+3. **Vérifier le pipeline bout-en-bout** :
+
+```bash
+# Générer des logs depuis un pod de test
+kubectl run log-test --image=busybox:1.37 --restart=Never -- \
+  sh -c 'for i in $(seq 1 10); do echo "Log de test $i - $(date)"; sleep 1; done'
+
+# Dans Kibana → Discover, chercher : "Log de test"
+# Les logs doivent apparaître dans les secondes qui suivent
+```
+
+**Questions :**
+1. Quelle est la latence entre l'émission d'un log et son apparition dans Kibana ?
+2. Quels champs Kubernetes sont automatiquement ajoutés par le filtre `kubernetes_metadata` ?
+3. Comment filtrer les logs d'un seul namespace dans Kibana ?
+
+---
+
+### 8.6 Nettoyage
+
+```bash
+kubectl delete -f 08-fluentd-daemonset.yaml
+kubectl delete -f 10-kibana.yaml
+kubectl delete -f 09-elasticsearch.yaml
+kubectl delete namespace logging
+```
 
 ## Partie 9 : Bonnes pratiques
 

--- a/tp04/README.md
+++ b/tp04/README.md
@@ -1406,6 +1406,24 @@ La stack EFK centralise les logs de tous les pods du cluster dans une interface 
 
 ### 8.2 Déployer Elasticsearch
 
+> **Prérequis — `vm.max_map_count`**
+>
+> Elasticsearch exige que le paramètre noyau `vm.max_map_count` soit ≥ 262144 sur chaque nœud.
+> À configurer **avant** de déployer, selon votre environnement :
+>
+> ```bash
+> # minikube
+> minikube ssh -- 'sudo sysctl -w vm.max_map_count=262144'
+>
+> # kind
+> docker exec -it $(docker ps -qf name=kind) sysctl -w vm.max_map_count=262144
+>
+> # kubeadm / bare metal (sur chaque nœud)
+> sudo sysctl -w vm.max_map_count=262144
+> echo "vm.max_map_count=262144" | sudo tee /etc/sysctl.d/99-elasticsearch.conf
+> sudo sysctl --system
+> ```
+
 **Exercice 14 : Déployer Elasticsearch**
 
 ```bash


### PR DESCRIPTION
…connecté

La Partie 8 du TP4 ne déployait que Fluentd avec une sortie stdout, sans Elasticsearch ni Kibana. La pile EFK est maintenant complète.

- Ajouter 09-elasticsearch.yaml : StatefulSet nœud unique, namespace logging, xpack.security désactivé pour le TP, probes HTTP sur /_cluster/health
- Ajouter 10-kibana.yaml : Deployment + Service, pointe vers Elasticsearch via ELASTICSEARCH_HOSTS, probes sur /api/status
- Mettre à jour 08-fluentd-daemonset.yaml :
  - Image v1.19-debian-elasticsearch8-amd64-1 (inclut le plugin ES)
  - Sortie @type elasticsearch vers elasticsearch.logging.svc.cluster.local
  - Buffer fichier avec retry exponentiel
  - Toleration control-plane pour les clusters mono-nœud
- Réécrire la Partie 8 du README :
  - Schéma d'architecture du pipeline EFK
  - Exercices 14-17 : déploiement étape par étape (ES → Kibana → Fluentd)
  - Vérification des index, création du Data View Kibana
  - Pipeline bout-en-bout avec pod de test
  - Section nettoyage