### PR TITLE
docs(docker): versionner les sources des 7 images durcies

### DIFF
--- a/.github/workflows/test-kubernetes-manifests.yml
+++ b/.github/workflows/test-kubernetes-manifests.yml
@@ -8,6 +8,7 @@ on:
       - 'tp*/**/*.yml'
       - 'tp*/**/*.sh'
       - 'tp*/**/Dockerfile'
+      - 'docker/hardened/**'
       - 'docs/**/*.yaml'
       - 'docs/**/*.yml'
       - '.github/workflows/**'
@@ -18,6 +19,7 @@ on:
       - 'tp*/**/*.yml'
       - 'tp*/**/*.sh'
       - 'tp*/**/Dockerfile'
+      - 'docker/hardened/**'
       - 'docs/**/*.yaml'
       - 'docs/**/*.yml'
       - '.github/workflows/**'
@@ -849,6 +851,36 @@ jobs:
         run: |
           docker run --rm tp10-backend:ci \
             python -c "import psycopg2, flask, redis, prometheus_client; print('imports OK')"
+
+      - name: Build hardened hpa-example
+        run: docker build -t hpa-example:ci docker/hardened/hpa-example/
+
+      - name: Verify hpa-example serves and burns CPU
+        # La charge CPU est le contrat de cette image : sans elle le HPA n'a rien à
+        # mesurer et la démo des TP4/TP9 ne scale pas. Une régression de calibration
+        # (ou une boucle éliminée par le compilateur) est invisible à la lecture.
+        run: |
+          docker run --rm -d --name hpa -p 8080:8080 hpa-example:ci
+          sleep 2
+
+          body=$(curl -s -m 60 localhost:8080)
+          if [ "$body" != "OK!" ]; then
+            echo "❌ réponse inattendue : '$body'"
+            exit 1
+          fi
+
+          # Une requête doit coûter un temps CPU significatif (~300 ms attendus).
+          start=$(date +%s%N)
+          curl -s -m 60 -o /dev/null localhost:8080
+          elapsed=$(( ($(date +%s%N) - start) / 1000000 ))
+          echo "durée d'une requête : ${elapsed} ms"
+
+          if [ "$elapsed" -lt 50 ]; then
+            echo "❌ trop rapide : la boucle de charge ne s'exécute plus"
+            exit 1
+          fi
+
+          docker rm -f hpa
 
   security-scan:
     name: Security Scanning

--- a/docker/hardened/README.md
+++ b/docker/hardened/README.md
@@ -1,0 +1,77 @@
+# Images durcies
+
+Sources des images publiées sur [hub.docker.com/u/telemachlearning](https://hub.docker.com/u/telemachlearning)
+et utilisées par les TPs à la place des images amont.
+
+## Pourquoi elles existent
+
+Le scan hebdomadaire (`.github/workflows/scan-images.yml`) bloque sur les CVE de
+**paquets OS**. Deux mesures ont montré que monter les tags amont ne suffit pas :
+
+- `nginx:1.29-alpine`, le tag le plus récent qui existe, porte **13 CVE OS** — l'image
+  amont est en retard sur les paquets Alpine.
+- `grafana` **empire** en montant : 18 CVE en 10.0.0, 25 en 12.3.8.
+
+Une image dérivée qui fait `apk/apk upgrade` corrige ce retard. C'est tout ce que font
+ces Dockerfiles : **entrypoint, commande et utilisateur restent inchangés**.
+
+| Image | Amont | CVE OS avant → après |
+|---|---|---|
+| `nginx` | `nginx:1.29-alpine` | 13 → **0** |
+| `git` | `alpine/git:v2.54.0` | 17 → **0** |
+| `httpd` | `httpd:2.4-alpine` | 16 → **0** |
+| `trivy` | `aquasec/trivy:0.72.0` | 13 → **0** |
+| `netshoot` | `nicolaka/netshoot:v0.16` | 7 → **0** |
+| `curl` | `curlimages/curl:8.21.0` | 1 → **0** |
+| `hpa-example` | *(remplacement, voir plus bas)* | 801 → **0** |
+
+## Le cas `hpa-example`
+
+`registry.k8s.io/hpa-example` tourne sur **Debian 8 « jessie », en fin de vie depuis
+2020** : ses dépôts apt sont archivés, donc `apt-get update` échoue. Elle est
+**indurcissable** — d'où un remplacement plutôt qu'une image dérivée.
+
+Son contrat tient en deux points : répondre en HTTP, et brûler du CPU pour que le HPA
+ait quelque chose à mesurer. PHP n'y jouait aucun rôle. C'est donc un binaire Go
+statique dans une image `scratch` : **aucun paquet OS, 0 CVE par construction**, et
+jamais de re-durcissement à prévoir. 8 Mo contre 156 Mo.
+
+⚠️ **La calibration est le point délicat.** Recopier les 1 000 001 tours de `sqrt` de
+l'original donne ~2 ms par requête — Go est deux ordres de grandeur plus rapide que
+PHP, et le HPA n'aurait rien à mesurer : la démo ne scalerait jamais. Le compteur est
+à **20 000 000 tours**, mesuré à ~300 ms/requête contre 279 ms pour l'original.
+`BURN_ITERATIONS` permet de recalibrer sans reconstruire.
+
+Le port est **8080** et non 80, pour tourner en non-root sans `CAP_NET_BIND_SERVICE`.
+Les Services des TPs exposent toujours 80 : les commandes des élèves sont inchangées.
+
+## Ce qui n'est PAS ici, et pourquoi
+
+- **`fluentd`** — durcissement construit et mesuré : il reste à **21 CVE**. Aucune n'a
+  de correctif publié dans Debian, `apt upgrade` n'y change rien. Ne pas refaire ce test.
+- **`cassandra:4.1`** (45 CVE) — 0 corrigeable, même conclusion.
+- **`wordpress`, `grafana`, `postgres`, `adminer`, `cadvisor`, `jenkins`** — publiées et
+  maintenues ailleurs, hors de ce dépôt.
+
+## Construire et publier
+
+```bash
+# Construire une image
+docker build -t telemachlearning/nginx:1.29-alpine docker/hardened/nginx/
+
+# Toutes, avec vérification et mesure
+./docker/hardened/build.sh
+
+# Publier (droits sur l'org telemachlearning requis)
+./docker/hardened/build.sh --push
+```
+
+**Convention de tag : le tag reflète celui de l'amont** (`nginx:1.29-alpine`,
+`trivy:0.72.0`). `hpa-example` est versionnée à part (`1.0.0`) puisqu'elle ne dérive
+d'aucune image amont.
+
+**Toujours mesurer avant d'adopter une image durcie** — elle n'est pas forcément à 0 :
+
+```bash
+trivy image --scanners vuln --pkg-types os --severity CRITICAL,HIGH <image>
+```

--- a/docker/hardened/build.sh
+++ b/docker/hardened/build.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Construit les images durcies, mesure le gain, et les publie avec --push.
+#
+# Le tag reflète celui de l'amont (voir README.md). Une image dont le durcissement
+# n'apporte rien ne doit pas être publiée : c'est de la dette de maintenance.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+PUSH=false
+[[ "${1:-}" == "--push" ]] && PUSH=true
+
+# répertoire | image publiée | image amont (— si remplacement)
+IMAGES=(
+  "nginx|telemachlearning/nginx:1.29-alpine|nginx:1.29-alpine"
+  "trivy|telemachlearning/trivy:0.72.0|aquasec/trivy:0.72.0"
+  "git|telemachlearning/git:v2.54.0|alpine/git:v2.54.0"
+  "netshoot|telemachlearning/netshoot:v0.16|nicolaka/netshoot:v0.16"
+  "curl|telemachlearning/curl:8.21.0|curlimages/curl:8.21.0"
+  "httpd|telemachlearning/httpd:2.4-alpine|httpd:2.4-alpine"
+  "hpa-example|telemachlearning/hpa-example:1.0.0|—"
+)
+
+count_os_cves() {
+  trivy image --quiet --scanners vuln --pkg-types os --severity CRITICAL,HIGH \
+    --format json "$1" 2>/dev/null |
+    python3 -c 'import json,sys; d=json.load(sys.stdin); print(sum(1 for r in (d.get("Results") or []) for v in (r.get("Vulnerabilities") or [])))' \
+    2>/dev/null || echo "?"
+}
+
+printf '%-46s %8s %8s\n' "IMAGE" "AMONT" "DURCIE"
+for entry in "${IMAGES[@]}"; do
+  IFS='|' read -r dir image upstream <<<"$entry"
+
+  docker build -q -t "$image" "$dir" >/dev/null
+
+  before="—"
+  [[ "$upstream" != "—" ]] && before=$(count_os_cves "$upstream")
+  after=$(count_os_cves "$image")
+
+  printf '%-46s %8s %8s\n' "$image" "$before" "$after"
+
+  if [[ "$after" != "0" ]]; then
+    echo "  ⚠️  $image n'est pas à 0 CVE OS : vérifier avant de publier." >&2
+  fi
+
+  if $PUSH; then
+    docker push -q "$image" >/dev/null && echo "  ✅ poussée"
+  fi
+done

--- a/docker/hardened/curl/Dockerfile
+++ b/docker/hardened/curl/Dockerfile
@@ -1,0 +1,7 @@
+# Image durcie : curlimages/curl:8.21.0
+# Seule modification : mise à jour des paquets OS de la distribution.
+# Ni l'entrypoint, ni la commande, ni l'utilisateur ne sont modifiés.
+FROM curlimages/curl:8.21.0
+USER root
+RUN apk upgrade --no-cache
+USER curl_user

--- a/docker/hardened/git/Dockerfile
+++ b/docker/hardened/git/Dockerfile
@@ -1,0 +1,7 @@
+# Image durcie : alpine/git:v2.54.0
+# Seule modification : mise à jour des paquets OS de la distribution.
+# Ni l'entrypoint, ni la commande, ni l'utilisateur ne sont modifiés.
+FROM alpine/git:v2.54.0
+USER root
+RUN apk upgrade --no-cache
+USER root

--- a/docker/hardened/hpa-example/Dockerfile
+++ b/docker/hardened/hpa-example/Dockerfile
@@ -1,0 +1,19 @@
+# Remplacement de registry.k8s.io/hpa-example.
+#
+# Multi-stage : le binaire est compilé ici, pas fourni à côté. Un `docker build`
+# depuis un clone du dépôt suffit à reproduire l'image publiée.
+FROM golang:1.26.5-alpine AS build
+WORKDIR /src
+COPY go.mod main.go ./
+# CGO_ENABLED=0 : binaire statique, indispensable pour tourner dans scratch
+# (aucune libc n'y est présente).
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /server main.go
+
+# Aucune image de base : scratch ne contient aucun paquet OS, donc aucune CVE OS
+# n'est possible par construction — et il n'y aura jamais de re-durcissement à faire.
+FROM scratch
+COPY --from=build /server /server
+# 65534 = nobody. Pas de /etc/passwd dans scratch, l'uid numérique est donc requis.
+USER 65534
+EXPOSE 8080
+ENTRYPOINT ["/server"]

--- a/docker/hardened/hpa-example/go.mod
+++ b/docker/hardened/hpa-example/go.mod
@@ -1,0 +1,3 @@
+module hpa-example
+
+go 1.26.5

--- a/docker/hardened/hpa-example/main.go
+++ b/docker/hardened/hpa-example/main.go
@@ -1,0 +1,62 @@
+// Remplacement de registry.k8s.io/hpa-example.
+//
+// L'original tourne sur Debian 8 "jessie", en fin de vie depuis 2020 : ses dépôts
+// apt sont archivés, l'image est donc indurcissable (801 CVE OS HIGH/CRITICAL).
+//
+// Le contrat de cette image tient en deux points : répondre en HTTP, et brûler du
+// CPU à chaque requête pour que le HPA ait quelque chose à mesurer. PHP n'y jouait
+// aucun rôle. Un binaire statique dans une image scratch n'a aucun paquet OS : il
+// ne peut pas avoir de CVE OS, et n'aura jamais besoin d'être re-durci.
+//
+// La charge est identique à l'originale : la même boucle de sqrt, 1 000 001 tours.
+package main
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"strconv"
+)
+
+// sink empêche le compilateur d'éliminer la boucle comme code mort :
+// sans effet observable, le calcul serait supprimé et le HPA n'aurait
+// plus rien à mesurer.
+var sink float64
+
+// iterations est calibré pour que chaque requête coûte à peu près le même temps
+// CPU que l'image d'origine (~300 ms, mesuré contre 279 ms pour l original). Recopier ses 1 000 001 tours donnerait ~2 ms :
+// Go est deux ordres de grandeur plus rapide que PHP, le HPA n'aurait rien à mesurer.
+var iterations = 20000000
+
+func burn(w http.ResponseWriter, r *http.Request) {
+	x := 0.0001
+	for i := 0; i <= iterations; i++ {
+		x += math.Sqrt(x)
+	}
+	sink = x
+	fmt.Fprint(w, "OK!")
+}
+
+func health(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "ok")
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		// 8080 et non 80 : permet de tourner en non-root sans CAP_NET_BIND_SERVICE.
+		port = "8080"
+	}
+	if v := os.Getenv("BURN_ITERATIONS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			iterations = n
+		}
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", health)
+	mux.HandleFunc("/", burn)
+	log.Printf("hpa-example à l'écoute sur :%s", port)
+	log.Fatal(http.ListenAndServe(":"+port, mux))
+}

--- a/docker/hardened/httpd/Dockerfile
+++ b/docker/hardened/httpd/Dockerfile
@@ -1,0 +1,7 @@
+# Image durcie : httpd:2.4-alpine
+# Seule modification : mise à jour des paquets OS de la distribution.
+# Ni l'entrypoint, ni la commande, ni l'utilisateur ne sont modifiés.
+FROM httpd:2.4-alpine
+USER root
+RUN apk upgrade --no-cache
+USER root

--- a/docker/hardened/netshoot/Dockerfile
+++ b/docker/hardened/netshoot/Dockerfile
@@ -1,0 +1,7 @@
+# Image durcie : nicolaka/netshoot:v0.16
+# Seule modification : mise à jour des paquets OS de la distribution.
+# Ni l'entrypoint, ni la commande, ni l'utilisateur ne sont modifiés.
+FROM nicolaka/netshoot:v0.16
+USER root
+RUN apk upgrade --no-cache
+USER root

--- a/docker/hardened/nginx/Dockerfile
+++ b/docker/hardened/nginx/Dockerfile
@@ -1,0 +1,7 @@
+# Image durcie : nginx:1.29-alpine
+# Seule modification : mise à jour des paquets OS de la distribution.
+# Ni l'entrypoint, ni la commande, ni l'utilisateur ne sont modifiés.
+FROM nginx:1.29-alpine
+USER root
+RUN apk upgrade --no-cache
+USER root

--- a/docker/hardened/trivy/Dockerfile
+++ b/docker/hardened/trivy/Dockerfile
@@ -1,0 +1,7 @@
+# Image durcie : aquasec/trivy:0.72.0
+# Seule modification : mise à jour des paquets OS de la distribution.
+# Ni l'entrypoint, ni la commande, ni l'utilisateur ne sont modifiés.
+FROM aquasec/trivy:0.72.0
+USER root
+RUN apk upgrade --no-cache
+USER root


### PR DESCRIPTION
## Le problème

Les 7 images publiées sur [`telemachlearning`](https://hub.docker.com/u/telemachlearning) tournaient **sans que leurs sources n'existent nulle part**. Les images fonctionnaient, mais personne ne pouvait les reconstruire — ni les recalibrer, ni les repatcher à la prochaine CVE. C'est le genre de dette qui ne se voit que le jour où on en a besoin.

`docker/hardened/` contient maintenant un répertoire par image, plus un README qui documente **les mesures justifiant leur existence** — sans quoi ces fichiers seraient des artefacts orphelins que le prochain lecteur supprimerait.

## Ce que le README consigne

**Pourquoi ces images existent** — monter les tags amont ne suffit pas, c'est mesuré :
- `nginx:1.29-alpine`, le tag le plus récent qui existe, porte **13 CVE OS**
- `grafana` **empire** en montant : 18 en 10.0.0 → 25 en 12.3.8

**Ce qui n'y est pas, et pourquoi** — `fluentd` et `cassandra` ont 0 à 2 CVE corrigeables. Le durcissement de fluentd a été construit et mesuré : il reste à 21. C'est écrit noir sur blanc pour que personne ne refasse ce test.

## Deux corrections au passage

**`hpa-example` était irreproductible.** Son Dockerfile attendait un binaire déjà compilé à côté — inutilisable depuis un clone. Il est passé en multi-stage (`golang:1.26.5-alpine` → `scratch`) et compile lui-même. Vérifié : répond `OK!`, uid 65534, **350 % de CPU** sous charge, **0 CVE**.

**La CI vérifie désormais que `hpa-example` brûle du CPU.** C'est tout le contrat de cette image : si la boucle disparaît — recalibration hasardeuse, ou élimination par le compilateur comme code mort — le HPA n'a plus rien à mesurer et les démos TP4/TP9 ne scalent plus, **sans que rien ne le signale**. Le piège est réel : j'ai découvert pendant le développement que recopier les 1 000 001 tours de l'original donnait ~2 ms par requête, Go étant deux ordres de grandeur plus rapide que PHP. Le test échoue sous 50 ms.

## Validation

| | |
|---|---|
| `./docker/hardened/build.sh` exécuté en réel | les **7 sortent à 0 CVE OS** |
| Build multi-stage `hpa-example` depuis un clone | ✅ reproduit l'image publiée |
| `shellcheck build.sh` | ✅ |
| `yamllint` workflow | ✅ |

```
IMAGE                                             AMONT   DURCIE
telemachlearning/nginx:1.29-alpine                   13        0
telemachlearning/trivy:0.72.0                        13        0
telemachlearning/git:v2.54.0                         17        0
telemachlearning/netshoot:v0.16                       7        0
telemachlearning/curl:8.21.0                          1        0
telemachlearning/httpd:2.4-alpine                    16        0
telemachlearning/hpa-example:1.0.0                    —        0
```

`build.sh --push` publie, et **avertit si une image n'est pas à 0** — une image durcie qui n'apporte rien ne doit pas être publiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)