### PR TITLE
fix(images): réduire les CVE par des bumps mesurés, et ne bloquer que sur l'actionnable

### DIFF
--- a/.claude/AUTOMATION.md
+++ b/.claude/AUTOMATION.md
@@ -287,13 +287,15 @@ scan échouera en tentant de la puller.
 python3 .github/scripts/extract-images.py --verbose
 ```
 
-### Politique de résultat : bloquant sur les CVE de paquets OS
+### Politique de résultat : bloquant sur ce qui est actionnable, et rien d'autre
 
-Le scan **échoue** (exit 1) sur les CVE HIGH/CRITICAL **de paquets OS**
-(`vuln-type: 'os'`). Les CVE de binaires embarqués (gobinary, jar, node-pkg…) sont
-scannées et publiées dans l'onglet Security, mais **ne bloquent pas**.
+Le scan **échoue** (exit 1) sur les CVE HIGH/CRITICAL **de paquets OS ayant un
+correctif publié** (`vuln-type: 'os'` + `ignore-unfixed: true`). Autrement dit :
+**le rouge veut dire « il y a quelque chose à faire »**, jamais « il existe une CVE ».
 
-Ce n'est pas un assouplissement de complaisance, c'est ce que la mesure impose :
+Deux filtres, et l'ordre du raisonnement compte.
+
+**1. `vuln-type: os` — écarter ce qui ne dépend pas de nous.**
 
 | Seuil | Images vertes (sur 38) |
 |---|---|
@@ -305,16 +307,47 @@ Sur les 38 images, **12 n'ont que des CVE de binaires** (`prom/prometheus`, `etc
 une image tierce ne part que si l'amont recompile : la signaler en rouge chaque
 semaine n'offre aucune action possible. Elles sont en outre largement non
 atteignables — un binaire qui n'appelle jamais `net/http` embarque quand même les
-CVE de la stdlib.
+CVE de la stdlib. Leur nombre suit d'ailleurs **l'âge du build** (~5-6 par mois pour
+un binaire Go, mesuré le 2026-07-17) et non le risque : `etcd:v3.5.32`, publiée
+16 jours plus tôt, en portait 1 ; `mysqld-exporter:v0.19.0`, publiée 4 mois plus tôt,
+en portait 24.
 
-⚠️ `--ignore-unfixed` **ne** répond **pas** à ce problème : il retient les CVE dont un
-correctif existe en amont, pas celles qu'on peut appliquer.
+**2. `ignore-unfixed: true` — écarter ce sur quoi on ne peut rien.**
+
+Sans ce filtre, la barrière est rouge **à vie** sur `wordpress` (156 CVE OS),
+`cassandra:4.1` (45) et `fluent/fluentd` (21) : elles n'ont **aucun** correctif
+publié. Une alarme permanente qu'on n'a aucun moyen d'éteindre finit par être
+ignorée — et masque les vraies.
+
+⚠️ **Une version antérieure de ce document rejetait `--ignore-unfixed`**, au motif
+qu'il « retient les CVE dont un correctif existe en amont, pas celles qu'on peut
+appliquer ». Ce rejet visait une barrière **toutes catégories**, où il aurait laissé
+passer des CVE de binaires « corrigeables » mais inapplicables sans recompilation
+amont. Appliqué **après** le filtre OS, il n'a plus ce défaut : pour un paquet de
+distribution, un correctif publié **est** applicable — en montant le tag, ou par un
+`apk/apt upgrade` si l'image est déjà au tag le plus récent (cf. `docker/hardened/`).
+Les deux filtres sont complémentaires, pas concurrents.
+
+**Rien n'est masqué durablement.** Une CVE sans correctif aujourd'hui redevient
+bloquante le jour où la distribution en publie un, **sans liste à maintenir**. C'est
+le principal avantage sur un `.trivyignore` qui énumérerait ces CVE : une liste figée
+masquerait précisément le correctif qu'on attend.
+
+**Exceptions : `.trivyignore.yaml`.** Réservé au cas restant — une CVE OS *corrigeable*
+qu'on choisit de ne pas corriger tout de suite. Justification et `expired_at`
+obligatoires (le champ est vérifié : une entrée périmée rebloque le job). Ce fichier
+n'est lu que par l'étape de barrière, **jamais** par les scans qui alimentent l'onglet
+Security : une exception lève un blocage, elle n'efface pas une CVE.
 
 **Le rouge est attribuable à une image précise.** Le job de chaque image devient rouge
 si cette image est vulnérable, et le job `report` rend le même verdict sur l'ensemble.
-Les deux lisent le même seuil, la variable `FAIL_ON_SEVERITY` définie en tête du
-workflow : ils ne peuvent donc pas diverger. Si toutes les images passent, `report`
-passe aussi.
+
+⚠️ **Partager `FAIL_ON_SEVERITY` ne suffit pas à garantir ce même verdict** — il faut
+aussi le même **périmètre** et les mêmes **exceptions**. Ça a été un vrai bug : le
+rapport comptait *toutes* les CVE et sortait en échec alors que toutes les images
+étaient vertes. `image-scan-report.py` ventile donc les CVE en trois catégories
+(OS corrigeables / OS sans correctif / binaires) et lit le même `.trivyignore.yaml`
+que la barrière. Ne toucher à l'un des deux qu'en vérifiant l'autre.
 
 L'échec n'est jamais porté par les étapes de scan elles-mêmes, mais par une étape
 **gate placée en dernier**, après les uploads. C'est volontaire : mettre

--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -370,6 +370,68 @@ Le problème persistait après la première correction. Investigation complémen
 - PGDATA pointe vers `/var/lib/postgresql/data/pgdata` (sous-répertoire)
 - PostgreSQL peut créer ce sous-répertoire avec les bonnes permissions
 
+### Session 2026-07-17 - Réduction des CVE d'images
+
+**Objectif** : traiter les images encore vulnérables au scan hebdomadaire.
+
+**Point de départ, et le malentendu à ne pas refaire** : le rapport lu était le **scan
+complet** (onglet Security : 118 CRITICAL / 1478 HIGH sur 17 images). La **barrière CI
+ne bloque que sur les CVE de paquets OS** (`vuln-type: 'os'`), et n'était rouge que sur
+**5 images**. Les deux périmètres ne se comparent pas.
+
+**La colonne « corrigeables » de Trivy ne veut pas dire « corrigeable en montant le
+tag »** : elle compte les CVE ayant un correctif *publié*. Pour une CVE de binaire Go,
+le correctif n'arrive que si l'amont recompile. D'où la règle : **mesurer chaque bump**.
+
+**Mesures (2026-07-17)** :
+
+| Image | Avant (C/H) | Après | Résultat |
+|---|---|---|---|
+| `prom/prometheus` v2.45.0 / v2.48.0 | 8/90, 8/79 | **v3** | **0 / 0** |
+| `quay.io/coreos/etcd` v3.5.10 | 9/109 | **v3.5.32** | 0 / 3 |
+| `quay.io/brancz/prometheus-example-app` v0.5.0 | 4/52 | **v0.6.0** | 0 / 17 |
+| `prom/mysqld-exporter` v0.15.1 | 2/35 | **v0.19.0** | 0 / 25 |
+| `tensorflow/tensorflow:2.18.0-gpu` | 21/378 | **supprimée** | — |
+
+**Décisions** :
+1. **Prometheus v2 → v3** : la branche v2 ne reçoit plus de correctif (v2.55.1, la
+   dernière, porte encore 78 CVE). Les 3 configs du dépôt sont **valides en v3 sans
+   modification** (`promtool check config` + `check rules`, v3.13.1). Tag **roulant
+   `v3`** et non `v3.13.1` : les CVE de Prometheus sont dans son binaire Go, qu'un tag
+   de patch fige — c'est exactement ce qui a fait pourrir v2.45.0 (cf. la leçon
+   `mysql:8.4` vs `mysql:8.4.0` dans `tp03/12-mysql-deployment-secure.yaml`).
+   ⚠️ v3 est **strict sur le `Content-Type`** au scrape : une cible tolérée en v2 peut
+   échouer en v3. Vérifié pour `prometheus-example-app` (`text/plain; version=0.0.4`).
+2. **TensorFlow abandonnée** plutôt que durcie. Durcir ne pouvait pas la rendre verte :
+   ~182 CVE Ubuntu **sans correctif amont** subsistent quel que soit le tag. Elle
+   servait de décor dans un Job GPU qui ne peut pas s'exécuter (pas de nœud
+   `gpu: nvidia`, `train.py` inexistant, fichier appliqué en `--dry-run=client`).
+   Remplacée par `python:3.13-alpine` : **0 CVE, 17 Mo** contre 3,8 Go.
+3. **Elasticsearch / Kibana laissées en 8.17.7** : monter serait **contre-productif**.
+   8.17.7 a **0 CVE OS** (donc verte) ; 8.19.10 en introduit 2, et 9.2.4 bascule sur une
+   base RedHat à 25 CVE OS dont 14 sans correctif. Le scan complet n'y gagnerait que 7.
+
+**Bug préexistant corrigé au passage** : le sidecar `mysql-exporter` du TP3 était
+**cassé**. `DATA_SOURCE_NAME` n'est plus lu depuis la v0.15.0 — l'exporter échouait sur
+`no user specified in section or parent`, y compris en v0.15.1. Remplacé par
+`--mysqld.username` + `MYSQLD_EXPORTER_PASSWORD`, **vérifié contre un vrai MySQL 8.4
+(`mysql_up 1`)**.
+
+**Impasses documentées** dans `docker/hardened/README.md` (ne pas re-tester) :
+`netshoot:v0.16` (déjà la dernière version amont, 0 CVE OS, ses CVE sont dans les
+binaires Go embarqués), `postgres:15/17-alpine`, `mysql:8.4`, `cassandra:4.1` (tags
+roulants à jour, CVE dans `gosu`), `wordpress` et `fluentd` (0 corrigeable).
+
+**Barrière CI : 5 images rouges → 4** (wordpress, cassandra, les 2 fluentd). Aucune
+n'est actionnable depuis ce dépôt.
+
+**Non traité** : `gcr.io/kaniko-project/executor:v1.23.2` (v1.24.0 ne gagne que 117→111,
+0 CVE OS donc déjà vert) ; `docs/AIRGAP_DEPLOYMENT.md` et `docs/IMAGE_REGISTRY_DMZ.md`
+citent encore `quay.io/prometheus/prometheus:v2.45.0` (markdown non scanné, illustration
+de miroir airgap) ; 43 misconfigurations `trivy config` HIGH préexistantes dans
+`tp04/` et `tp09/examples/` — inchangées par cette session, mais elles contredisent
+l'objectif « 0 vulnérabilité HIGH/CRITICAL » affiché dans CLAUDE.md.
+
 ## Décisions importantes
 
 ### Architecture d'automatisation (2025-12-12)

--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -432,6 +432,61 @@ de miroir airgap) ; 43 misconfigurations `trivy config` HIGH préexistantes dans
 `tp04/` et `tp09/examples/` — inchangées par cette session, mais elles contredisent
 l'objectif « 0 vulnérabilité HIGH/CRITICAL » affiché dans CLAUDE.md.
 
+### Session 2026-07-17 (suite) - Le rouge doit vouloir dire « à faire »
+
+**Origine** : en cherchant à documenter les CVE restantes, découverte que le job
+`report` **divergeait de la barrière** — et que sa formulation était la cause du
+malentendu qui a ouvert la session.
+
+**Deux bugs dans `image-scan-report.py`** :
+1. **Verdict divergent.** La barrière filtrait `vuln-type: os` ; le rapport comptait
+   **toutes** les CVE et sortait en échec. Reproduit : 3 images toutes vertes à la
+   barrière → rapport en code 1. Le commentaire de `FAIL_ON_SEVERITY` promettait
+   pourtant l'inverse. **Partager la gravité ne suffit pas : il faut le même
+   périmètre et les mêmes exceptions.**
+2. **Formulation trompeuse.** Le rapport annonçait « *disposant d'un correctif publié
+   (corrigeables en montant le tag de l'image)* » — faux pour une CVE de binaire, dont
+   le « correctif » désigne le toolchain Go. Il conseillait même de monter
+   `postgres:17-alpine`, **un tag roulant déjà au plus récent**. Le rapport enseignait
+   le mauvais modèle mental.
+
+**Correction : `ignore-unfixed: true` en complément du filtre OS.**
+
+Mesuré : les 4 images rouges l'étaient sur des CVE OS **sans correctif publié**
+(wordpress 0 corrigeable / 156, cassandra 0/45, fluentd 0/21, fluentd-daemonset 2/28).
+La barrière était donc rouge **à vie, sans action possible** — de la fatigue d'alarme.
+Avec `ignore-unfixed`, seul reste rouge ce qui est actionnable.
+
+⚠️ `AUTOMATION.md` **rejetait** `--ignore-unfixed`. Ce rejet visait une barrière
+*toutes catégories* (où « corrigeable » ≠ « applicable » pour un binaire Go).
+Appliqué **après** le filtre OS, il n'a plus ce défaut : pour un paquet de
+distribution, un correctif publié est applicable. Les deux filtres sont
+complémentaires. `AUTOMATION.md` a été corrigé en conséquence.
+
+**Réponse à « comment se passe la montée de version ? » : automatiquement.** Le jour
+où la distribution publie un correctif pour l'une des 45 CVE de cassandra, elle
+redevient corrigeable → la barrière repasse au rouge → on agit. **Aucune liste à
+maintenir**, et pas le risque qu'un `.trivyignore` figé masque le correctif attendu.
+
+**`.trivyignore.yaml`** (nouveau) : réservé au cas restant — une CVE OS *corrigeable*
+qu'on choisit de ne pas corriger tout de suite. `expired_at` obligatoire, **vérifié**
+(une entrée périmée rebloque bien le job). Lu **uniquement** par la barrière, jamais
+par les scans alimentant l'onglet Security : une exception lève un blocage, elle
+n'efface pas une CVE. Le job `scan-image` a reçu un `checkout` (il n'en avait pas :
+le fichier aurait été ignoré en silence) et le job `report` un `pip install pyyaml`.
+
+**Seule entrée à ce jour** : les 2 CVE `libcurl4t64` de `fluentd-kubernetes-daemonset`
+(8.14.1-2+deb13u3 → +deb13u4). Debian a publié le correctif, l'image fluentd n'a pas
+été reconstruite : le vrai remède est un durcissement `apt upgrade` publié sur
+telemachlearning. **Acceptation temporaire jusqu'au 2026-08-31.**
+
+**Nouveau rapport** : ventile en 3 catégories (OS corrigeables / OS sans correctif /
+binaires) + une colonne « exceptées ». Seule la 1ʳᵉ bloque. Le rapport lit le même
+`.trivyignore.yaml` que la barrière — les deux ne peuvent plus diverger. Sans
+fichier d'exceptions, il **bloque** (échoue fermé).
+
+**État** : barrière verte sur les 33 images. Tout rouge futur = réellement actionnable.
+
 ## Décisions importantes
 
 ### Architecture d'automatisation (2025-12-12)

--- a/.github/scripts/image-scan-report.py
+++ b/.github/scripts/image-scan-report.py
@@ -2,11 +2,22 @@
 """Agrège les rapports JSON de Trivy en un résumé Markdown.
 
 Lit tous les fichiers *.json d'un répertoire (un par image, produits par le
-workflow scan-images.yml) et produit un tableau récapitulatif trié par gravité,
-suivi de la liste des images à mettre à jour en priorité.
+workflow scan-images.yml) et produit un tableau récapitulatif, suivi de la liste
+des images réellement actionnables.
 
-Avec --fail-on, sort en code 1 si des vulnérabilités des gravités données sont
-trouvées : c'est ce qui fait échouer le scan hebdomadaire.
+Le rapport classe les CVE en trois catégories, parce qu'elles n'appellent pas la
+même action :
+
+  1. CVE de paquet OS AVEC correctif publié -> actionnable, et seule catégorie
+     bloquante. Se corrige en montant le tag, ou par un `apk/apt upgrade` si
+     l'image est déjà au tag le plus récent (cf. docker/hardened/).
+  2. CVE de paquet OS SANS correctif publié -> rien à faire tant que la distro
+     n'a pas publié. Redeviendra automatiquement bloquante ce jour-là.
+  3. CVE de binaire embarqué (gobinary, jar, node-pkg…) -> ne part que si l'amont
+     recompile. Hors de portée de ce dépôt.
+
+Le verdict (--fail-on) ne porte que sur la catégorie 1, pour rendre le même
+verdict que la barrière par image du workflow (vuln-type: os + ignore-unfixed).
 
 Usage :
     python3 .github/scripts/image-scan-report.py <dossier-des-rapports>
@@ -14,46 +25,118 @@ Usage :
 """
 
 import argparse
+import datetime
 import json
 import sys
 from pathlib import Path
 
 SEVERITIES = ("CRITICAL", "HIGH", "MEDIUM", "LOW")
 
+# Trivy classe chaque Result : "os-pkgs" pour les paquets de la distribution,
+# "lang-pkgs" pour les binaires et bibliothèques embarqués.
+OS_CLASS = "os-pkgs"
 
-def summarize(report_path: Path) -> dict:
-    """Compte les vulnérabilités d'un rapport Trivy par gravité."""
+
+def load_exceptions(ignore_file: Path) -> set:
+    """Les CVE exceptées et non expirées de .trivyignore.yaml.
+
+    Le rapport DOIT appliquer les mêmes exceptions que la barrière : sans ça, les
+    deux divergent (rapport rouge / images vertes), ce qui est précisément le
+    défaut que la séparation OS/binaire corrige par ailleurs.
+
+    Le rapprochement se fait sur l'ID seul, là où Trivy croise aussi le purl. Un
+    même ID de CVE sur un autre paquet serait donc excepté ici et pas par la
+    barrière — cas de figure sans occurrence réelle, l'écart resterait de toute
+    façon du côté prudent (le job échoue, le rapport non).
+    """
+    if not ignore_file.is_file():
+        return set()
+
+    try:
+        import yaml
+    except ImportError:
+        print(f"⚠️ pyyaml absent : exceptions de {ignore_file.name} non appliquées.",
+              file=sys.stderr)
+        return set()
+
+    try:
+        data = yaml.safe_load(ignore_file.read_text(encoding="utf-8")) or {}
+    except (yaml.YAMLError, OSError) as error:
+        print(f"⚠️ {ignore_file.name} illisible : {error}", file=sys.stderr)
+        return set()
+
+    today = datetime.date.today()
+    active = set()
+    for entry in data.get("vulnerabilities") or []:
+        expiry = entry.get("expired_at")
+        if isinstance(expiry, datetime.datetime):
+            expiry = expiry.date()
+        # Une exception expirée redevient bloquante : c'est tout l'intérêt du champ.
+        if isinstance(expiry, datetime.date) and expiry <= today:
+            continue
+        if entry.get("id"):
+            active.add(entry["id"])
+    return active
+
+
+def _empty() -> dict:
+    return {severity: 0 for severity in SEVERITIES}
+
+
+def summarize(report_path: Path, exceptions: set) -> dict:
+    """Ventile les vulnérabilités d'un rapport Trivy par gravité et par action possible."""
     data = json.loads(report_path.read_text(encoding="utf-8"))
 
-    counts = {severity: 0 for severity in SEVERITIES}
-    # Une vulnérabilité "corrigeable" a une version de correctif publiée :
-    # c'est celle sur laquelle on peut agir en montant le tag de l'image.
-    fixable = {severity: 0 for severity in SEVERITIES}
+    # Une CVE de paquet OS "corrigeable" a une version de correctif publiée par la
+    # distribution : celle-là, et elle seule, se règle depuis ce dépôt.
+    os_fixable = _empty()
+    os_unfixable = _empty()
+    # Corrigeables mais explicitement exceptées et datées dans .trivyignore.yaml.
+    # Comptées à part plutôt que soustraites en silence : une exception se voit.
+    excepted = _empty()
+    # Les CVE de binaires embarqués ont beau afficher une FixedVersion (ex : Go
+    # 1.26.5 pour une CVE stdlib), elle désigne le toolchain amont, pas une image :
+    # les distinguer par correctif n'apporterait rien, on ne les sépare donc pas.
+    binary = _empty()
 
     for result in data.get("Results") or []:
+        is_os = result.get("Class") == OS_CLASS
         for vuln in result.get("Vulnerabilities") or []:
             severity = vuln.get("Severity")
-            if severity not in counts:
+            if severity not in SEVERITIES:
                 continue
-            counts[severity] += 1
-            if vuln.get("FixedVersion"):
-                fixable[severity] += 1
+            if not is_os:
+                binary[severity] += 1
+            elif not vuln.get("FixedVersion"):
+                os_unfixable[severity] += 1
+            elif vuln.get("VulnerabilityID") in exceptions:
+                excepted[severity] += 1
+            else:
+                os_fixable[severity] += 1
 
     return {
         "image": data.get("ArtifactName", report_path.stem),
-        "counts": counts,
-        "fixable": fixable,
+        "os_fixable": os_fixable,
+        "os_unfixable": os_unfixable,
+        "excepted": excepted,
+        "binary": binary,
     }
 
 
-def status_icon(counts: dict) -> str:
-    if counts["CRITICAL"]:
+def status_icon(item: dict, fail_on: list) -> str:
+    """L'icône suit le verdict : rouge = actionnable, donc bloquant."""
+    blocking = [s for s in (fail_on or ["CRITICAL", "HIGH"]) if item["os_fixable"][s]]
+    if blocking:
         return "🔴"
-    if counts["HIGH"]:
-        return "🟠"
-    if counts["MEDIUM"] or counts["LOW"]:
+    if any(item["excepted"].values()):
+        return "⚪"
+    if any(item["os_unfixable"].values()) or any(item["binary"].values()):
         return "🟡"
     return "🟢"
+
+
+def _ch(counts: dict) -> str:
+    return f"{counts['CRITICAL']}/{counts['HIGH']}"
 
 
 def main() -> int:
@@ -63,6 +146,11 @@ def main() -> int:
         "--fail-on",
         default="",
         help="gravités faisant sortir en code 1, séparées par des virgules (ex: CRITICAL,HIGH)",
+    )
+    parser.add_argument(
+        "--ignorefile",
+        default=".trivyignore.yaml",
+        help="exceptions datées, à garder identique à celui que lit la barrière",
     )
     args = parser.parse_args()
 
@@ -78,68 +166,99 @@ def main() -> int:
         print("⚠️ Aucun rapport de scan trouvé.")
         return 0
 
+    exceptions = load_exceptions(Path(args.ignorefile))
+
     summaries = []
     for report_file in report_files:
         try:
-            summaries.append(summarize(report_file))
+            summaries.append(summarize(report_file, exceptions))
         except (json.JSONDecodeError, OSError) as error:
             print(f"⚠️ Rapport illisible ({report_file.name}) : {error}", file=sys.stderr)
 
-    # Les images les plus critiques en premier
+    # Les images actionnables en premier, puis les plus bruyantes.
     summaries.sort(
         key=lambda item: (
-            -item["counts"]["CRITICAL"],
-            -item["counts"]["HIGH"],
+            -item["os_fixable"]["CRITICAL"],
+            -item["os_fixable"]["HIGH"],
+            -item["os_unfixable"]["CRITICAL"],
             item["image"],
         )
     )
 
-    totals = {severity: sum(item["counts"][severity] for item in summaries) for severity in SEVERITIES}
-    fixable_critical = sum(item["fixable"]["CRITICAL"] for item in summaries)
-    fixable_high = sum(item["fixable"]["HIGH"] for item in summaries)
-    clean = sum(1 for item in summaries if not any(item["counts"].values()))
+    def total(bucket: str, severity: str) -> int:
+        return sum(item[bucket][severity] for item in summaries)
+
+    actionable = [
+        item for item in summaries
+        if any(item["os_fixable"][s] for s in (fail_on or ["CRITICAL", "HIGH"]))
+    ]
+    clean = sum(
+        1 for item in summaries
+        if not any(item[b][s] for b in ("os_fixable", "os_unfixable", "excepted", "binary")
+                   for s in SEVERITIES)
+    )
 
     print("## 🔎 Scan de vulnérabilités des images\n")
     print(f"**{len(summaries)} image(s) scannée(s)** — {clean} sans vulnérabilité connue.\n")
-    print(
-        f"| CRITICAL | HIGH | MEDIUM | LOW |\n|---:|---:|---:|---:|\n"
-        f"| {totals['CRITICAL']} | {totals['HIGH']} | {totals['MEDIUM']} | {totals['LOW']} |\n"
-    )
-    print(
-        f"Dont **{fixable_critical} CRITICAL** et **{fixable_high} HIGH** disposant d'un correctif "
-        f"publié (corrigeables en montant le tag de l'image).\n"
-    )
+
+    print("### 🔴 Actionnable — CVE de paquets OS avec correctif publié\n")
+    print("C'est la seule catégorie bloquante, et la seule sur laquelle ce dépôt peut agir :")
+    print("monter le tag, ou durcir l'image par `apk/apt upgrade` si elle est déjà au tag le")
+    print("plus récent (voir `docker/hardened/`).\n")
+    print("| CRITICAL | HIGH | MEDIUM | LOW |\n|---:|---:|---:|---:|")
+    print(f"| {total('os_fixable','CRITICAL')} | {total('os_fixable','HIGH')} "
+          f"| {total('os_fixable','MEDIUM')} | {total('os_fixable','LOW')} |\n")
+
+    print("### 🟡 Informatif — non actionnable depuis ce dépôt\n")
+    print("| Catégorie | CRITICAL | HIGH | MEDIUM | LOW | Pourquoi |")
+    print("|---|---:|---:|---:|---:|---|")
+    print(f"| CVE de paquets OS **sans correctif** | {total('os_unfixable','CRITICAL')} "
+          f"| {total('os_unfixable','HIGH')} | {total('os_unfixable','MEDIUM')} "
+          f"| {total('os_unfixable','LOW')} | La distribution n'a rien publié. "
+          f"Redeviendra bloquante dès qu'un correctif sortira. |")
+    if any(total("excepted", s) for s in SEVERITIES):
+        print(f"| CVE **exceptées** (`.trivyignore.yaml`) | {total('excepted','CRITICAL')} "
+              f"| {total('excepted','HIGH')} | {total('excepted','MEDIUM')} "
+              f"| {total('excepted','LOW')} | Corrigeables, mais acceptées "
+              f"temporairement avec justification et date d'expiration. |")
+    print(f"| CVE de **binaires embarqués** | {total('binary','CRITICAL')} "
+          f"| {total('binary','HIGH')} | {total('binary','MEDIUM')} | {total('binary','LOW')} "
+          f"| Ne partent que si l'amont recompile. Leur nombre suit l'âge du build "
+          f"(~5-6/mois pour un binaire Go), pas un risque nouveau. |\n")
 
     print("### Détail par image\n")
-    print("| | Image | CRITICAL | HIGH | MEDIUM | LOW | Corrigeables (C/H) |")
-    print("|---|---|---:|---:|---:|---:|---:|")
+    print("🔴 à traiter · ⚪ excepté · 🟡 rien à faire · 🟢 sain\n")
+    print("| | Image | OS corrigeables (C/H) | Exceptées (C/H) "
+          "| OS sans correctif (C/H) | Binaires (C/H) |")
+    print("|---|---|---:|---:|---:|---:|")
     for item in summaries:
-        counts, fixable = item["counts"], item["fixable"]
         print(
-            f"| {status_icon(counts)} | `{item['image']}` "
-            f"| {counts['CRITICAL']} | {counts['HIGH']} | {counts['MEDIUM']} | {counts['LOW']} "
-            f"| {fixable['CRITICAL']}/{fixable['HIGH']} |"
+            f"| {status_icon(item, fail_on)} | `{item['image']}` "
+            f"| {_ch(item['os_fixable'])} | {_ch(item['excepted'])} "
+            f"| {_ch(item['os_unfixable'])} | {_ch(item['binary'])} |"
         )
 
-    to_bump = [item for item in summaries if item["fixable"]["CRITICAL"]]
-    if to_bump:
-        print("\n### ⚠️ À mettre à jour en priorité\n")
-        print("Ces images ont des vulnérabilités CRITICAL déjà corrigées en amont :\n")
-        for item in to_bump:
-            print(f"- `{item['image']}` — {item['fixable']['CRITICAL']} CRITICAL corrigeable(s)")
+    if actionable:
+        print("\n### ⚠️ À traiter\n")
+        for item in actionable:
+            print(f"- `{item['image']}` — {_ch(item['os_fixable'])} (CRITICAL/HIGH) "
+                  f"de paquets OS avec un correctif publié.")
+        print("\nSi l'image est déjà au tag le plus récent, monter le tag n'y changera rien :")
+        print("c'est un durcissement qu'il faut (`docker/hardened/`, un `apk/apt upgrade`).")
 
     print("\n> Détail complet des CVE : onglet **Security → Code scanning** du dépôt.")
 
     if not fail_on:
         return 0
 
-    blocking = {severity: totals[severity] for severity in fail_on if totals[severity]}
+    blocking = {s: total("os_fixable", s) for s in fail_on if total("os_fixable", s)}
     if not blocking:
-        print(f"\n✅ Aucune vulnérabilité {'/'.join(fail_on)} détectée.")
+        print(f"\n✅ Aucune CVE de paquet OS {'/'.join(fail_on)} corrigeable détectée.")
         return 0
 
     detail = ", ".join(f"{count} {severity}" for severity, count in blocking.items())
-    print(f"\n❌ **Scan en échec** : {detail} détectée(s) sur {len(summaries)} image(s).")
+    print(f"\n❌ **Scan en échec** : {detail} de paquets OS corrigeable(s) "
+          f"sur {len(actionable)} image(s).")
     return 1
 
 

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -23,9 +23,12 @@ permissions:
   contents: read
 
 env:
-  # Seuil de blocage, partagé par le gate de chaque image et par le rapport final :
-  # les deux doivent rendre le même verdict, sinon on retombe sur des images vertes
-  # avec un rapport rouge (ou l'inverse).
+  # Seuil de blocage, partagé par le gate de chaque image et par le rapport final.
+  #
+  # ⚠️ Partager la gravité ne suffit pas : les deux doivent aussi porter sur le même
+  # PÉRIMÈTRE (paquets OS, correctif publié), sinon ils divergent. C'est arrivé :
+  # le rapport comptait toutes les CVE et sortait en échec alors que toutes les
+  # images étaient vertes — exactement ce que cette variable prétendait empêcher.
   FAIL_ON_SEVERITY: 'CRITICAL,HIGH'
 
 jobs:
@@ -80,6 +83,12 @@ jobs:
         include: ${{ fromJson(needs.list-images.outputs.matrix) }}
 
     steps:
+      # Nécessaire au seul .trivyignore.yaml lu par la barrière en fin de job.
+      # Sans checkout, le fichier n'existe pas sur le runner et Trivy l'ignore en
+      # silence : les exceptions ne s'appliqueraient pas, sans la moindre erreur.
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Scan image with Trivy (SARIF)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -124,26 +133,39 @@ jobs:
           path: 'trivy-${{ matrix.slug }}.json'
           retention-days: 30
 
-      # BARRIÈRE : seules les CVE de paquets OS font rougir le job.
+      # BARRIÈRE : seules les CVE de paquets OS AVEC UN CORRECTIF PUBLIÉ font
+      # rougir le job. Autrement dit : le rouge signifie « il y a quelque chose à
+      # faire », jamais « il existe une CVE ».
       #
-      # Pourquoi pas toutes les CVE, ni --ignore-unfixed : sur une image tierce,
-      # une CVE de binaire (gobinary, jar...) ne part que si l'amont recompile.
-      # --ignore-unfixed ne filtre pas ça — il retient les CVE dont un correctif
-      # existe, pas celles qu'on peut appliquer. Mesuré sur ce dépôt : 33 images
-      # rouges avec toutes les CVE, dont 12 n'ont QUE des CVE de binaires Go.
-      # Ces CVE-là sont en plus largement non atteignables (un binaire qui
-      # n'appelle jamais net/http embarque quand même les CVE de la stdlib).
+      # Deux filtres complémentaires, et l'ordre du raisonnement compte :
       #
-      # Une CVE de paquet OS, elle, part avec une image plus récente : c'est la
-      # seule catégorie sur laquelle ce dépôt peut réellement agir.
+      # 1. vuln-type: os — une CVE de binaire (gobinary, jar...) ne part que si
+      #    l'amont recompile. Mesuré : 33 images rouges avec toutes les CVE, dont
+      #    12 n'ont QUE des CVE de binaires Go. Elles sont en plus largement non
+      #    atteignables (un binaire qui n'appelle jamais net/http embarque quand
+      #    même les CVE de la stdlib), et leur nombre suit l'âge du build, pas le
+      #    risque : ~5-6 nouvelles par mois sans que rien ne change dans l'image.
       #
-      # Le reste n'est pas perdu : le scan complet ci-dessus l'a déjà envoyé dans
-      # l'onglet Security, où il reste consultable pour jugement humain.
+      # 2. ignore-unfixed: true — une fois restreint aux paquets OS, « corrigeable »
+      #    veut enfin dire « applicable » : soit en montant le tag, soit par un
+      #    apk/apt upgrade (cf. docker/hardened/). Sans ce filtre, la barrière est
+      #    rouge à vie sur wordpress (156 CVE), cassandra (45) et fluentd (21), qui
+      #    n'ont AUCUN correctif publié : une alarme permanente qu'on finit par
+      #    ignorer, et qui masque les vraies.
+      #
+      # ⚠️ AUTOMATION.md rejetait --ignore-unfixed. Ce rejet visait une barrière
+      # TOUTES CATÉGORIES, où il aurait retenu des CVE de binaires « corrigeables »
+      # mais inapplicables. Appliqué APRÈS le filtre OS, il n'a plus ce défaut.
+      #
+      # Rien n'est masqué durablement : une CVE sans correctif aujourd'hui
+      # redevient bloquante le jour où la distribution en publie un — sans liste
+      # à maintenir. Et le scan complet ci-dessus a déjà tout envoyé dans l'onglet
+      # Security, où il reste consultable pour jugement humain.
       #
       # L'étape est en dernier : le SARIF et le JSON sont déjà uploadés, donc rien
       # n'est perdu au moment précis où il y a quelque chose à voir. L'image est en
       # cache depuis le premier scan, ce passage ne la retélécharge pas.
-      - name: Fail on OS package vulnerabilities
+      - name: Fail on fixable OS package vulnerabilities
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'image'
@@ -155,6 +177,11 @@ jobs:
           # trivy-action v0.36.0 (l'action le mappe vers TRIVY_PKG_TYPES). Un input
           # inconnu serait ignoré en silence et la barrière bloquerait sur tout.
           vuln-type: 'os'
+          ignore-unfixed: true
+          # Exceptions documentées et datées. Volontairement absent des étapes de
+          # scan ci-dessus : une exception lève le blocage, elle n'efface pas la
+          # CVE de l'onglet Security.
+          trivyignores: '.trivyignore.yaml'
           exit-code: '1'
           version: 'v0.72.0'
           timeout: '15m'
@@ -173,6 +200,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      # Le rapport lit .trivyignore.yaml pour appliquer les mêmes exceptions que la
+      # barrière. Sans pyyaml il ne planterait pas : il ignorerait les exceptions et
+      # rendrait un verdict divergent.
+      - name: Install dependencies
+        run: pip install pyyaml
 
       - name: Download all scan reports
         uses: actions/download-artifact@v4

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,54 @@
+# Exceptions à la barrière du scan d'images hebdomadaire (.github/workflows/scan-images.yml)
+#
+# ┌─ CE FICHIER N'EST PAS UN INTERRUPTEUR À BRUIT ─────────────────────────────┐
+# │ La barrière ne bloque déjà QUE sur les CVE de paquets OS ayant un correctif │
+# │ publié — c'est-à-dire uniquement sur ce qui est réellement actionnable.     │
+# │ Une CVE qui arrive ici est donc, par construction, une CVE qu'on POURRAIT   │
+# │ corriger et qu'on choisit de ne pas corriger tout de suite. Ça se justifie, │
+# │ ça se date, et ça ne se laisse pas traîner.                                 │
+# └────────────────────────────────────────────────────────────────────────────┘
+#
+# N'ONT RIEN À FAIRE ICI, parce que la barrière les écarte déjà toute seule :
+#
+#   - Les CVE de binaires embarqués (gobinary, jar, node-pkg…). Elles ne partent
+#     que si l'amont recompile, et leur nombre suit l'âge du build (~5-6 par mois
+#     pour un binaire Go) et non le risque. Filtrées par `vuln-type: os`.
+#   - Les CVE de paquets OS sans correctif publié (wordpress : 156, cassandra : 45,
+#     fluentd : 21). Filtrées par `ignore-unfixed: true`. Surtout, NE PAS les
+#     lister ici : elles doivent redevenir bloquantes automatiquement le jour où
+#     la distribution publie un correctif. Les figer ici masquerait précisément
+#     le correctif qu'on attend.
+#
+# PORTÉE : ce fichier n'est lu que par l'étape de barrière, jamais par les scans
+# qui alimentent l'onglet Security. Une exception lève un blocage ; elle n'efface
+# pas une CVE. Le détail reste consultable dans Security → Code scanning.
+#
+# `expired_at` est obligatoire et vérifié (testé : une entrée périmée rebloque
+# bien le job). C'est ce qui garantit qu'une exception est revue plutôt qu'oubliée.
+#
+# Format : https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids
+
+vulnerabilities:
+  # ── fluent/fluentd-kubernetes-daemonset:v1.19-debian-elasticsearch8-amd64-1 ──
+  # Debian a publié le correctif (libcurl4t64 8.14.1-2+deb13u3 → +deb13u4) ; c'est
+  # l'image fluentd qui n'a pas été reconstruite depuis. Le correctif est donc
+  # applicable, mais pas depuis un manifest : il faut durcir l'image
+  # (`docker/hardened/`, un simple `apt upgrade`) puis publier le résultat sur
+  # l'org partagée telemachlearning — ce qui demande une autorisation.
+  #
+  # Acceptation temporaire en attendant cette décision. À l'expiration, soit le
+  # durcissement est fait et ces deux entrées disparaissent, soit l'amont a
+  # reconstruit et elles deviennent sans objet.
+  - id: CVE-2026-5773
+    purl: "pkg:deb/debian/libcurl4t64"
+    statement: >-
+      libcurl4t64 8.14.1-2+deb13u3, corrigé en +deb13u4. Non corrigeable par un
+      bump de tag (l'image amont n'a pas été reconstruite) : nécessite un
+      durcissement apt upgrade + publication sur telemachlearning.
+    expired_at: 2026-08-31
+  - id: CVE-2026-6276
+    purl: "pkg:deb/debian/libcurl4t64"
+    statement: >-
+      Même paquet et même correctif que CVE-2026-5773 : libcurl4t64
+      8.14.1-2+deb13u3 → +deb13u4, en attente du durcissement de l'image.
+    expired_at: 2026-08-31

--- a/docker/hardened/README.md
+++ b/docker/hardened/README.md
@@ -50,8 +50,42 @@ Les Services des TPs exposent toujours 80 : les commandes des élèves sont inch
 - **`fluentd`** — durcissement construit et mesuré : il reste à **21 CVE**. Aucune n'a
   de correctif publié dans Debian, `apt upgrade` n'y change rien. Ne pas refaire ce test.
 - **`cassandra:4.1`** (45 CVE) — 0 corrigeable, même conclusion.
+- **`tensorflow/tensorflow:*-gpu`** — mesuré le 2026-07-17, **abandonnée** (elle ne
+  figure plus dans aucun manifest). Ne pas la réintroduire :
+
+  | Tag | CVE OS | dont corrigeables | Après `apt upgrade` |
+  |---|---|---|---|
+  | `2.18.0-gpu` | 381 | 199 | ~182 |
+  | `2.21.0-gpu` | 253 | 71 | ~182 |
+
+  Les deux tags convergent vers le même plancher de **~182 CVE Ubuntu sans correctif
+  amont** : durcir ne pouvait pas la rendre verte, pour 3,8 Go à construire, publier et
+  maintenir. La variante CPU n'aidait pas non plus (`2.21.0` : 252 CVE OS — les CVE sont
+  dans la base Ubuntu, pas dans les couches CUDA).
+
+  Elle servait de **décor** dans `tp09/examples/taints-tolerations-examples.yaml` : un
+  Job GPU qui ne peut pas s'exécuter (aucun nœud `gpu: nvidia` dans un cluster de
+  formation, et `train.py` n'existe dans aucune de ces images). Le fichier est appliqué
+  en `--dry-run=client`. Ce qui enseigne la planification GPU, c'est le `nodeSelector`,
+  la toleration et la ressource `nvidia.com/gpu` — pas l'image. Remplacée par
+  `python:3.13-alpine` : **0 CVE, 17 Mo**, et `command: ["python", "train.py"]` reste
+  cohérent.
 - **`wordpress`, `grafana`, `postgres`, `adminer`, `cadvisor`, `jenkins`** — publiées et
   maintenues ailleurs, hors de ce dépôt.
+
+## Images à ne PAS monter — le bump est contre-productif
+
+Mesuré le 2026-07-17. La barrière ne compte que les CVE **OS** : une image à 0 CVE OS
+est verte même si le scan complet lui trouve des CVE de binaires.
+
+- **`docker.elastic.co/elasticsearch/elasticsearch:8.17.7`** (et Kibana, qui doit rester
+  aligné) — **0 CVE OS aujourd'hui, donc verte**. Monter la ferait *rougir* :
+  `8.19.10` introduit 2 CVE OS Ubuntu, `9.2.4` bascule sur une base RedHat à 25 CVE OS
+  (dont 14 sans correctif). Le scan complet ne gagnerait que 7 CVE. Ne pas monter.
+- **`telemachlearning/netshoot:v0.16`** — déjà la dernière version amont. Ses ~167 CVE
+  sont dans les binaires Go des outils qu'elle embarque, pas dans l'OS : 0 CVE OS.
+- **`postgres:15/17-alpine`, `mysql:8.4`, `cassandra:4.1`** — tags roulants déjà à jour.
+  Leurs CVE viennent de binaires Go embarqués (`gosu`), pas des paquets OS.
 
 ## Construire et publier
 

--- a/tp03/12-mysql-deployment-secure.yaml
+++ b/tp03/12-mysql-deployment-secure.yaml
@@ -306,14 +306,17 @@ spec:
 
       # Sidecar pour exporter les métriques Prometheus (optionnel)
       - name: mysql-exporter
-        image: prom/mysqld-exporter:v0.15.1
+        image: prom/mysqld-exporter:v0.19.0
+        # L'exporter ne lit plus DATA_SOURCE_NAME depuis la v0.15.0 : la cible et
+        # l'utilisateur passent par des flags, le mot de passe par cette variable.
+        args:
+        - --mysqld.address=localhost:3306
+        - --mysqld.username=exporter
         ports:
         - containerPort: 9104
           name: metrics
         env:
-        - name: DATA_SOURCE_NAME
-          value: "exporter:$(MYSQL_EXPORTER_PASSWORD)@(localhost:3306)/"
-        - name: MYSQL_EXPORTER_PASSWORD
+        - name: MYSQLD_EXPORTER_PASSWORD
           valueFrom:
             secretKeyRef:
               name: mysql-secret-secure

--- a/tp04/04-prometheus-deployment.yaml
+++ b/tp04/04-prometheus-deployment.yaml
@@ -105,7 +105,11 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: prom/prometheus:v2.45.0
+        # v3 et non v3.13.1 : les CVE de Prometheus sont dans son binaire Go, et
+        # seule une nouvelle release les corrige. Un tag de patch se fige donc et
+        # pourrit (mesuré : 98 CVE HIGH/CRITICAL sur v2.45.0, 0 sur v3).
+        # La branche v2 ne reçoit plus de correctif : v2.55.1, la dernière, en porte 78.
+        image: prom/prometheus:v3
         args:
           - '--config.file=/etc/prometheus/prometheus.yml'
           - '--storage.tsdb.path=/prometheus'

--- a/tp04/06-instrumented-app.yaml
+++ b/tp04/06-instrumented-app.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: quay.io/brancz/prometheus-example-app:v0.5.0
+        image: quay.io/brancz/prometheus-example-app:v0.6.0
         ports:
         - containerPort: 8080
           name: metrics

--- a/tp04/07-prometheus-with-rules.yaml
+++ b/tp04/07-prometheus-with-rules.yaml
@@ -103,7 +103,8 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: prom/prometheus:v2.45.0
+        # Tag roulant v3 : voir 04-prometheus-deployment.yaml pour le pourquoi.
+        image: prom/prometheus:v3
         args:
           - '--config.file=/etc/prometheus/prometheus.yml'
           - '--storage.tsdb.path=/prometheus'

--- a/tp04/README.md
+++ b/tp04/README.md
@@ -549,7 +549,7 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: prom/prometheus:v2.45.0
+        image: prom/prometheus:v3
         args:
           - '--config.file=/etc/prometheus/prometheus.yml'
           - '--storage.tsdb.path=/prometheus'
@@ -1093,7 +1093,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: quay.io/brancz/prometheus-example-app:v0.5.0
+        image: quay.io/brancz/prometheus-example-app:v0.6.0
         ports:
         - containerPort: 8080
           name: metrics
@@ -1216,7 +1216,7 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: prom/prometheus:v2.45.0
+        image: prom/prometheus:v3
         args:
           - '--config.file=/etc/prometheus/prometheus.yml'
           - '--storage.tsdb.path=/prometheus'

--- a/tp09/README.md
+++ b/tp09/README.md
@@ -1519,7 +1519,9 @@ spec:
         effect: NoSchedule
       containers:
       - name: ml-training
-        image: tensorflow/tensorflow:latest-gpu
+        # L'image est un simple décor : ce qui aiguille ce Job vers un nœud GPU,
+        # c'est la toleration et la ressource nvidia.com/gpu, pas l'image.
+        image: python:3.13-alpine
         command: ["python", "train.py"]
         resources:
           limits:

--- a/tp09/examples/node-affinity-examples.yaml
+++ b/tp09/examples/node-affinity-examples.yaml
@@ -179,7 +179,7 @@ spec:
                 - "3"
       containers:
       - name: prometheus
-        image: prom/prometheus:v2.45.0
+        image: prom/prometheus:v3
         resources:
           requests:
             memory: "2Gi"

--- a/tp09/examples/poddisruptionbudget-examples.yaml
+++ b/tp09/examples/poddisruptionbudget-examples.yaml
@@ -151,7 +151,7 @@ spec:
     spec:
       containers:
       - name: etcd
-        image: quay.io/coreos/etcd:v3.5.10
+        image: quay.io/coreos/etcd:v3.5.32
         ports:
         - containerPort: 2379
           name: client

--- a/tp09/examples/taints-tolerations-examples.yaml
+++ b/tp09/examples/taints-tolerations-examples.yaml
@@ -134,7 +134,11 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: ml-training
-        image: tensorflow/tensorflow:2.18.0-gpu
+        # Image générique : ce qui fait de ce Job une charge GPU, c'est le
+        # nodeSelector, la toleration et la ressource nvidia.com/gpu ci-dessus —
+        # pas l'image. tensorflow:*-gpu tenait ce rôle de décor pour 3,8 Go et
+        # ~400 CVE dont ~182 sans correctif amont (voir docker/hardened/README.md).
+        image: python:3.13-alpine
         command: ["python", "train.py"]
         resources:
           limits:

--- a/tp10/18-prometheus-deployment.yaml
+++ b/tp10/18-prometheus-deployment.yaml
@@ -25,7 +25,9 @@ spec:
 
       containers:
       - name: prometheus
-        image: prom/prometheus:v2.48.0
+        # Tag roulant v3 : les CVE de Prometheus sont dans son binaire Go, qu'un
+        # tag de patch fige (mesuré : 87 CVE HIGH/CRITICAL sur v2.48.0, 0 sur v3).
+        image: prom/prometheus:v3
         args:
         - '--config.file=/etc/prometheus/prometheus.yml'
         - '--storage.tsdb.path=/prometheus'

--- a/tp10/README.md
+++ b/tp10/README.md
@@ -1420,7 +1420,7 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: prom/prometheus:v2.48.0
+        image: prom/prometheus:v3
         args:
         - '--config.file=/etc/prometheus/prometheus.yml'
         - '--storage.tsdb.path=/prometheus'


### PR DESCRIPTION
## Point de départ

Le rapport hebdomadaire annonçait **118 CRITICAL / 1478 HIGH sur 17 images**, dont
« 80 CRITICAL et 1065 HIGH corrigeables en montant le tag ».

Deux choses se cachaient derrière ce chiffre :

1. C'est le **scan complet**. La barrière CI ne bloque que sur les CVE de paquets OS
   et n'était rouge que sur **5 images**. Les deux périmètres ne se comparent pas.
2. La colonne « corrigeables » compte les CVE ayant un correctif **publié**, pas celles
   qu'un bump **applique**. Pour une CVE de binaire Go, le correctif n'arrive que si
   l'amont recompile. **Chaque bump de cette PR a donc été mesuré, pas extrapolé.**

## 1. Bumps retenus (mesurés)

| Image | Avant (C/H) | Après | Résultat |
|---|---|---|---|
| `prom/prometheus` v2.45.0 / v2.48.0 | 8/90, 8/79 | **v3** | **0 / 0** |
| `tensorflow/tensorflow:2.18.0-gpu` | 21/378 | **supprimée** | — |
| `quay.io/coreos/etcd` v3.5.10 | 9/109 | **v3.5.32** | 0 / 3 |
| `quay.io/brancz/prometheus-example-app` v0.5.0 | 4/52 | **v0.6.0** | 0 / 17 |
| `prom/mysqld-exporter` v0.15.1 | 2/35 | **v0.19.0** | 0 / 25 |

**1596 → 846 CVE HIGH/CRITICAL (−47 %)**, CRITICAL de 118 à 66.

**Prometheus v2 → v3** : la branche v2 ne reçoit plus de correctif (v2.55.1, la
dernière, en porte encore 78). Les 3 configs du dépôt sont **valides en v3 sans
modification** (`promtool check config` + `check rules`). Tag **roulant `v3`** : les CVE
de Prometheus sont dans son binaire Go, qu'un tag de patch fige — c'est exactement ce
qui a fait pourrir v2.45.0, conformément à la leçon `mysql:8.4` déjà écrite dans
`tp03/12-mysql-deployment-secure.yaml`.
⚠️ v3 est **strict sur le `Content-Type`** au scrape : vérifié pour
`prometheus-example-app`, les cibles kubelet/cAdvisor ne le seront qu'en cluster.

**TensorFlow abandonnée** plutôt que durcie : ~182 CVE Ubuntu **sans correctif amont**
subsistent quel que soit le tag — durcir ne pouvait pas la rendre verte, pour 3,8 Go à
maintenir. Elle servait de décor dans un Job GPU **inexécutable** (pas de nœud
`gpu: nvidia`, `train.py` inexistant, fichier appliqué en `--dry-run=client`).
Remplacée par `python:3.13-alpine` : **0 CVE, 17 Mo**.

**Elasticsearch / Kibana laissées en 8.17.7** : monter serait **contre-productif**.
8.17.7 a 0 CVE OS (verte) ; 8.19.10 en introduit 2, 9.2.4 bascule sur une base RedHat à
25 CVE OS dont 14 sans correctif.

## 2. Bug préexistant corrigé

Le sidecar `mysql-exporter` du TP3 était **cassé**. `DATA_SOURCE_NAME` n'est plus lu
depuis la v0.15.0 : l'exporter échouait sur `no user specified in section or parent`,
y compris en v0.15.1. Les élèves n'ont jamais eu de métriques MySQL.
Remplacé par `--mysqld.username` + `MYSQLD_EXPORTER_PASSWORD`, **vérifié contre un vrai
MySQL 8.4 (`mysql_up 1`)**.

## 3. Le rouge doit vouloir dire « à faire »

**Le job `report` divergeait de la barrière** : elle filtre `vuln-type: os`, il comptait
toutes les CVE et sortait en échec. Reproduit : 3 images **toutes vertes** à la barrière
→ rapport en code 1. Le commentaire de `FAIL_ON_SEVERITY` promettait l'inverse.
Partager la gravité ne suffit pas : il faut le même **périmètre** et les mêmes
**exceptions**.

Le rapport était aussi la **source du malentendu initial** : sa phrase « corrigeables en
montant le tag de l'image » est mot pour mot le chiffre cité en ouverture. Il conseillait
même de monter `postgres:17-alpine`, **un tag roulant déjà au plus récent**.

- `image-scan-report.py` ventile en 3 catégories qui n'appellent pas la même action :
  OS corrigeables (**seule bloquante**) / OS sans correctif / binaires.
- La barrière gagne **`ignore-unfixed: true`**. Mesuré : les 4 images rouges l'étaient
  sur des CVE **sans correctif** (wordpress 0/156, cassandra 0/45, fluentd 0/21) —
  rouge à vie, aucune action possible.
- ⚠️ `AUTOMATION.md` **rejetait** `--ignore-unfixed`. Ce rejet visait une barrière
  *toutes catégories*, où « corrigeable » ≠ « applicable » pour un binaire. Appliqué
  **après** le filtre OS, l'objection tombe. Document corrigé.

**La montée de version devient automatique** : le jour où une distribution publie un
correctif, la CVE redevient corrigeable → la barrière repasse au rouge. Aucune liste à
maintenir, et pas le risque qu'un `.trivyignore` figé masque le correctif attendu.

**`.trivyignore.yaml`** (nouveau) : réservé au seul cas restant — une CVE OS
*corrigeable* qu'on choisit de ne pas corriger tout de suite. `expired_at` obligatoire
et **vérifié empiriquement** (une entrée périmée rebloque le job). Lu **uniquement** par
la barrière : une exception lève un blocage, elle n'efface pas une CVE de l'onglet
Security. Absent → la barrière bloque (échec fermé).

Seule entrée : les 2 CVE `libcurl4t64` de `fluentd-kubernetes-daemonset`
(deb13u3 → **deb13u4**, correctif publié mais image non reconstruite en amont).
Acceptation datée au **2026-08-31**.

Deux pièges désamorcés : `scan-image` n'avait **aucun `checkout`** (`.trivyignore.yaml`
aurait été ignoré **en silence**) et `report` n'installait pas `pyyaml` (exceptions non
appliquées, sans erreur).

## Validation

- `kubeconform -strict` : **57 ressources valides**, 0 erreur.
- `trivy config` : **aucune misconfiguration introduite** (comparé fichier par fichier
  à `main` — les 43 HIGH de `tp04/` et `tp09/examples/` préexistent à l'identique).
- Barrière : **verte sur les 33 images**. Rapport : **code 0**, aligné.
- `promtool check config` / `check rules` (v3.13.1) sur les 3 configs Prometheus.
- `mysqld-exporter` : `mysql_up 1` contre un MySQL 8.4 réel.

## Reste à décider

Le vrai remède pour `fluentd-kubernetes-daemonset` est de **durcir l'image**
(`apt upgrade`, motif de `docker/hardened/`) et de la publier sur `telemachlearning`.
Non fait : l'org est partagée. Sur autorisation, je construis, je mesure, et je retire
les 2 entrées du `.trivyignore.yaml`.

Non traité : `docs/AIRGAP_DEPLOYMENT.md` et `docs/IMAGE_REGISTRY_DMZ.md` citent encore
`quay.io/prometheus/prometheus:v2.45.0` (markdown non scanné, illustration de miroir
airgap) ; les 43 misconfigurations `trivy config` préexistantes contredisent l'objectif
« 0 vulnérabilité HIGH/CRITICAL » affiché dans `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)