### PR TITLE
fix(rbac): traiter les 6 misconfigurations isolées de trivy config

### DIFF
--- a/.claude/AUTOMATION.md
+++ b/.claude/AUTOMATION.md
@@ -385,6 +385,33 @@ non-corrigeables demandent un changement d'image ou une acceptation du risque.
 - `CRITICAL,HIGH` → valeur actuelle
 - `CRITICAL` → seuls les CRITICAL bloquent
 
+## 🧾 Exceptions aux misconfigurations : `.trivyignore-manifests.yaml`
+
+**Ne pas confondre avec `.trivyignore.yaml`**, qui couvre les CVE d'images et n'est lu
+que par la barrière du scan hebdomadaire. Deux régimes distincts :
+
+| | `.trivyignore.yaml` | `.trivyignore-manifests.yaml` |
+|---|---|---|
+| Couvre | CVE d'images | Misconfigurations `trivy config` |
+| Lu par | la barrière de `scan-images.yml` | le job `security-scan` |
+| Effet | lève un blocage, **n'efface pas** la CVE de l'onglet Security | retire l'alerte du rapport — ce job **n'a pas de barrière**, sans quoi l'exception n'aurait aucun effet |
+| `expired_at` | **obligatoire** | **absent, volontairement** |
+
+**Pourquoi pas d'`expired_at` côté manifests** : une CVE exceptée est un report, la date
+force la reprise. Une exception pédagogique est structurelle — elle ne cessera pas d'être
+vraie à une date donnée. Lui coller une échéance ne créerait qu'un rendez-vous où l'on
+reconduirait la même décision. Ce qui la périme, c'est la suppression du fichier visé.
+
+**Critère d'entrée, strict** : n'y entre qu'une règle dont le respect **supprimerait la
+notion que le fichier enseigne**. Un `securityContext` manquant n'y a pas sa place —
+l'ajouter alourdit un exemple, ça ne le détruit pas.
+
+Deux entrées à ce jour, toutes deux vérifiées irréductibles :
+`KSV-0041` sur `tp05/05-clusterrole-secret-reader.yaml` (même avec `resourceNames` et le
+seul verbe `get`, l'alerte persiste) et `KSV-0108` sur
+`tp08/examples/04-externalname-service.yaml` (le fichier entier *est* l'objet visé).
+Chaque entrée a son pendant en commentaire dans le manifest lui-même.
+
 ## 🔁 Re-durcissement mensuel des images
 
 ### Emplacement

--- a/.github/workflows/test-kubernetes-manifests.yml
+++ b/.github/workflows/test-kubernetes-manifests.yml
@@ -910,6 +910,15 @@ jobs:
           # prétend pas surveiller. C'est ainsi qu'un DS-0026 (LOW, « pas de
           # HEALTHCHECK ») s'est retrouvé signalé sur une PR.
           limit-severities-for-sarif: true
+          # Exceptions aux misconfigurations. Fichier SÉPARÉ de .trivyignore.yaml,
+          # qui couvre les CVE d'images et n'est lu que par la barrière du scan
+          # hebdomadaire : deux régimes, deux périmètres, deux règles d'expiration.
+          #
+          # Contrairement au scan d'images, ce job n'a PAS de barrière (exit-code 0) :
+          # il ne fait qu'alimenter l'onglet Security. L'exception agit donc bien sur
+          # ce qui est rapporté — sans quoi elle n'aurait aucun effet. N'y entre que
+          # ce dont le respect supprimerait la notion enseignée par le fichier.
+          trivyignores: '.trivyignore-manifests.yaml'
 
       - name: Upload Trivy results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.trivyignore-manifests.yaml
+++ b/.trivyignore-manifests.yaml
@@ -1,0 +1,60 @@
+# Exceptions aux MISCONFIGURATIONS de manifests (job `security-scan` de
+# .github/workflows/test-kubernetes-manifests.yml, `trivy config`).
+#
+# ┌─ POURQUOI UN FICHIER SÉPARÉ DE .trivyignore.yaml ──────────────────────────┐
+# │ `.trivyignore.yaml` couvre les CVE d'IMAGES et n'est lu que par la barrière │
+# │ du scan hebdomadaire. Les deux régimes n'ont ni le même périmètre, ni la    │
+# │ même règle d'expiration (voir plus bas). Les mélanger rendrait chacun des   │
+# │ deux fichiers illisible, et une exception d'image pourrait taire une        │
+# │ misconfiguration par accident.                                             │
+# └────────────────────────────────────────────────────────────────────────────┘
+#
+# CE QUI PEUT ENTRER ICI, et rien d'autre : une règle dont le respect
+# SUPPRIMERAIT LA NOTION QUE LE FICHIER ENSEIGNE. C'est un critère strict, pas
+# un jugement de commodité. Un `securityContext` manquant n'y a pas sa place :
+# l'ajouter alourdit un exemple, ça ne le détruit pas — et la décision prise le
+# 2026-07-27 est de durcir ces cas-là (KSV-0014, KSV-0118), pas de les excepter.
+#
+# PAS D'`expired_at` ICI, contrairement à `.trivyignore.yaml`. Une CVE exceptée
+# est un report : la date force la reprise. Une exception pédagogique est
+# structurelle — elle ne cessera pas d'être vraie à une date donnée. Lui coller
+# une échéance ne créerait qu'un rendez-vous où l'on reconduirait la même
+# décision. Ce qui la périme, c'est la suppression du fichier concerné.
+#
+# Chaque entrée doit avoir son pendant : un commentaire dans le manifest lui-même,
+# pour que l'élève qui lit le fichier comprenne pourquoi Trivy proteste.
+#
+# Format : https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids
+
+misconfigurations:
+  # ── tp05/05-clusterrole-secret-reader.yaml ──
+  # Ce fichier existe pour démontrer un ClusterRole, et le fait sur l'exemple le
+  # plus parlant qui soit : la lecture de secrets à l'échelle du cluster. Trivy
+  # condamne tout accès aux secrets par ClusterRole, quelle que soit la
+  # restriction — vérifié le 2026-07-27 : avec `resourceNames` limité à un seul
+  # secret ET le verbe `get` seul, KSV-0041 se déclenche encore. Il n'existe donc
+  # aucune écriture de ce manifest qui conserve la démonstration et éteigne
+  # l'alerte : c'est excepter ou supprimer le TP.
+  #
+  # Le manifest applique déjà le moindre privilège atteignable : `get` et `list`
+  # uniquement, aucun verbe d'écriture.
+  - id: KSV-0041
+    paths:
+      - "tp05/05-clusterrole-secret-reader.yaml"
+    statement: >-
+      Démonstration pédagogique d'un ClusterRole (TP5 - RBAC). L'alerte porte sur
+      la notion même qu'enseigne le fichier. Aucune écriture ne l'éteint, testé
+      avec resourceNames + get seul. Le rôle est déjà en lecture seule.
+
+  # ── tp08/examples/04-externalname-service.yaml ──
+  # Le fichier entier EST un Service de type ExternalName — huit lignes dont le
+  # seul objet est d'enseigner ce type de Service, aux côtés de ClusterIP,
+  # NodePort et LoadBalancer dans le même répertoire. Respecter KSV-0108 revient
+  # à supprimer le fichier.
+  - id: KSV-0108
+    paths:
+      - "tp08/examples/04-externalname-service.yaml"
+    statement: >-
+      Démonstration pédagogique du type de Service ExternalName (TP8 - Réseau).
+      Le manifest ne contient que cet objet : respecter la règle reviendrait à
+      supprimer l'exemple.

--- a/tp04/04-prometheus-deployment.yaml
+++ b/tp04/04-prometheus-deployment.yaml
@@ -165,7 +165,9 @@ rules:
 - apiGroups: [""]
   resources:
   - nodes
-  - nodes/proxy
+  # Pas de `nodes/proxy` : il autorise le proxy vers N'IMPORTE QUEL endpoint du
+  # kubelet, pas seulement /metrics — d'où KSV-0047 (escalade de privilèges).
+  # Les jobs ci-dessus scrapent le kubelet en direct, `nodes/metrics` suffit.
   - nodes/metrics
   - services
   - endpoints

--- a/tp05/05-clusterrole-secret-reader.yaml
+++ b/tp05/05-clusterrole-secret-reader.yaml
@@ -1,3 +1,14 @@
+# 🔐 Trivy signale KSV-0041 (CRITICAL) sur ce fichier, et il a raison sur le fond :
+# un ClusterRole donnant accès aux secrets les rend lisibles dans TOUS les namespaces
+# du cluster, y compris kube-system. C'est exactement ce que ce TP veut montrer.
+#
+# L'alerte porte donc sur la notion enseignée, pas sur une négligence : vérifié le
+# 2026-07-27, même en limitant à un seul secret par `resourceNames` et au seul verbe
+# `get`, KSV-0041 se déclenche encore. L'exception est dans `.trivyignore-manifests.yaml`.
+#
+# En production, préférer un Role namespacé (voir 06-developer-role.yaml) : le
+# ClusterRole ne se justifie que pour un composant qui doit réellement travailler
+# sur tout le cluster.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -5,6 +16,8 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
+  # Lecture seule : aucun verbe d'écriture. C'est le moindre privilège atteignable
+  # sans renoncer à la démonstration.
   verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tp05/06-developer-role.yaml
+++ b/tp05/06-developer-role.yaml
@@ -14,17 +14,22 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log"]
   verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["pods/exec"]
-  verbs: ["create"]
+# Pas de `pods/exec` (KSV-0053) : ouvrir un shell dans un conteneur contourne tout
+# ce que le Deployment déclare — securityContext, image scannée, variables — et
+# n'apparaît dans aucun audit de ressource. Un développeur diagnostique avec
+# `kubectl logs` (autorisé ci-dessus) et `kubectl describe`. Si un exec est
+# vraiment nécessaire, il doit être une élévation explicite et tracée, pas un
+# droit permanent.
 # Deployments
 - apiGroups: ["apps"]
   resources: ["deployments", "replicasets"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]
-# Services
+# Services : lecture seule (KSV-0056). Créer ou modifier un Service permet de
+# détourner le trafic d'une application vers un autre pod — c'est une opération
+# de plateforme, pas de développement.
 - apiGroups: [""]
   resources: ["services"]
-  verbs: ["get", "list", "watch", "create", "update"]
+  verbs: ["get", "list", "watch"]
 # ConfigMaps et Secrets
 - apiGroups: [""]
   resources: ["configmaps"]

--- a/tp05/README.md
+++ b/tp05/README.md
@@ -317,17 +317,15 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log"]
   verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["pods/exec"]
-  verbs: ["create"]
+# Pas de `pods/exec` (KSV-0053) : voir l'encadré ci-dessous.
 # Deployments
 - apiGroups: ["apps"]
   resources: ["deployments", "replicasets"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]
-# Services
+# Services : lecture seule (KSV-0056)
 - apiGroups: [""]
   resources: ["services"]
-  verbs: ["get", "list", "watch", "create", "update"]
+  verbs: ["get", "list", "watch"]
 # ConfigMaps et Secrets
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -350,6 +348,28 @@ roleRef:
   name: developer-role
   apiGroup: rbac.authorization.k8s.io
 ```
+
+> 🔐 **Pourquoi ce Role n'accorde ni `pods/exec` ni l'écriture sur les Services**
+>
+> Les deux sont tentants pour un profil « développeur », et tous deux sont signalés
+> par Trivy (KSV-0053 et KSV-0056).
+>
+> **`pods/exec`** ouvre un shell dans le conteneur : cela contourne tout ce que le
+> Deployment déclare — `securityContext`, image scannée, variables d'environnement —
+> et n'apparaît dans aucun audit de ressource, puisque rien n'est créé ni modifié.
+> Diagnostiquer se fait avec `kubectl logs` et `kubectl describe`, tous deux
+> autorisés ici. Si un `exec` est réellement nécessaire, il doit être une élévation
+> explicite et tracée, pas un droit permanent.
+>
+> **Créer ou modifier un Service** permet de changer le sélecteur d'un Service
+> existant, donc de détourner le trafic d'une application vers un pod contrôlé par
+> l'attaquant, sans toucher au Deployment. C'est une opération de plateforme.
+>
+> Vérifiez-le après avoir appliqué le manifest :
+> ```bash
+> kubectl auth can-i create pods/exec --as=system:serviceaccount:default:developer-sa
+> # no
+> ```
 
 **Exercice 4 : Tester le role développeur**
 

--- a/tp08/examples/04-externalname-service.yaml
+++ b/tp08/examples/04-externalname-service.yaml
@@ -1,6 +1,16 @@
 # Exemple : ExternalName Service
 # Utilisation : kubectl apply -f 04-externalname-service.yaml
 # Test : kubectl run tmp --image=busybox --rm -it -- nslookup external-db
+#
+# 🔐 Trivy signale KSV-0108 (« Service with External IP ») sur ce fichier : un
+# Service qui pointe hors du cluster échappe aux NetworkPolicies, et son nom DNS
+# peut être détourné si le domaine change de main. Mais c'est précisément le type
+# de Service que cet exemple enseigne — le respecter reviendrait à supprimer le
+# fichier. Exception dans `.trivyignore-manifests.yaml`.
+#
+# En production : vérifier que le domaine visé est bien maîtrisé, et se souvenir
+# qu'ExternalName ne fait AUCUN contrôle (ni TLS, ni autorisation) — c'est un
+# simple alias DNS (CNAME).
 
 apiVersion: v1
 kind: Service

--- a/tp10/15-prometheus-config.yaml
+++ b/tp10/15-prometheus-config.yaml
@@ -63,10 +63,13 @@ data:
           regex: '(.*):10250'
           replacement: '${1}:10250'
           target_label: __address__
-        - source_labels: [__meta_kubernetes_node_name]
-          regex: (.+)
-          target_label: __metrics_path__
-          replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+        # Le kubelet expose /metrics/cadvisor directement sur son port 10250.
+        # La version précédente demandait /api/v1/nodes/<node>/proxy/metrics/cadvisor
+        # — un chemin de l'APISERVER — à une adresse qui est celle du KUBELET :
+        # celui-ci répondait 404, le job ne remontait aucune métrique. Passer par
+        # l'apiserver aurait en plus exigé `nodes/proxy` dans le ClusterRole.
+        - target_label: __metrics_path__
+          replacement: /metrics/cadvisor
         # Ajouter le nom du node comme label
         - source_labels: [__meta_kubernetes_node_name]
           target_label: node

--- a/tp10/16-prometheus-rbac.yaml
+++ b/tp10/16-prometheus-rbac.yaml
@@ -12,8 +12,10 @@ rules:
 - apiGroups: [""]
   resources:
   - nodes
+  # Pas de `nodes/proxy` : il autorise le proxy vers N'IMPORTE QUEL endpoint du
+  # kubelet, pas seulement /metrics — d'où KSV-0047 (escalade de privilèges).
+  # Le job cadvisor scrape le kubelet en direct, `nodes/metrics` suffit.
   - nodes/metrics
-  - nodes/proxy
   - services
   - endpoints
   - pods


### PR DESCRIPTION
Premier lot du chantier des misconfigurations `trivy config`. Sur les 261 alertes
HIGH/CRITICAL du dépôt, **6 sortaient du lot** : elles décrivent un vrai risque de
configuration, pas un durcissement absent. Les 255 `KSV-0014` / `KSV-0118` restantes
(securityContext, readOnlyRootFilesystem) feront l'objet de lots séparés par TP.

## Quatre corrigées en retirant le droit, pas en le masquant

| Alerte | Fichier | Ce qui a été retiré |
|---|---|---|
| `KSV-0047` | `tp04/04-prometheus-deployment.yaml` | `nodes/proxy` |
| `KSV-0047` | `tp10/16-prometheus-rbac.yaml` | `nodes/proxy` |
| `KSV-0053` | `tp05/06-developer-role.yaml` | `pods/exec: create` |
| `KSV-0056` | `tp05/06-developer-role.yaml` | écriture sur `services` |

**`nodes/proxy`** autorise le proxy vers *n'importe quel* endpoint du kubelet, pas
seulement `/metrics`. Les deux TP déclaraient déjà `nodes/metrics` et scrapent le kubelet
en direct : le droit ne servait à rien.

**`pods/exec`** ouvre un shell dans le conteneur — cela contourne tout ce que le
Deployment déclare (`securityContext`, image scannée, variables) et n'apparaît dans aucun
audit de ressource, puisque rien n'est créé ni modifié.

**Modifier un Service** permet de changer son sélecteur, donc de détourner le trafic
d'une application vers un pod contrôlé par l'attaquant, sans toucher au Deployment.

## 🐛 Un bug trouvé en chemin : la config cadvisor du tp10 ne marchait pas

`tp10/15-prometheus-config.yaml` demandait `/api/v1/nodes/<node>/proxy/metrics/cadvisor`
— un chemin de l'**apiserver** — à une adresse réécrite en `<node>:10250`, c'est-à-dire
celle du **kubelet**. Le kubelet répondait 404 : **le job ne remontait aucune métrique**.

Corrigé en `/metrics/cadvisor`, ce qui supprime du même coup le besoin de `nodes/proxy`.
La faille de sécurité et le bug fonctionnel avaient la même cause.

## Deux exceptées, après vérification qu'elles sont irréductibles

- **`KSV-0041` (CRITICAL)** — `tp05/05-clusterrole-secret-reader.yaml`. Testé le
  2026-07-27 : même avec `resourceNames` limité à un seul secret **et** le seul verbe
  `get`, l'alerte se déclenche encore. Trivy condamne tout accès aux secrets par
  ClusterRole. Or le fichier existe pour démontrer un ClusterRole : aucune écriture ne
  conserve la démonstration et éteint l'alerte.
- **`KSV-0108`** — `tp08/examples/04-externalname-service.yaml`, huit lignes dont le seul
  objet est d'enseigner ce type de Service.

Elles vont dans un fichier **séparé**, `.trivyignore-manifests.yaml` : `.trivyignore.yaml`
couvre les CVE d'images et n'est lu que par la barrière du scan hebdomadaire. Mélanger
les deux rendrait chaque fichier illisible, et une exception d'image pourrait taire une
misconfiguration par accident.

**Pas d'`expired_at` ici**, contrairement au fichier des CVE. Une CVE exceptée est un
report : la date force la reprise. Une exception pédagogique est structurelle — lui
coller une échéance ne créerait qu'un rendez-vous où l'on reconduirait la même décision.

Chaque entrée a son pendant en commentaire **dans le manifest**, pour que l'élève qui lit
le fichier comprenne pourquoi Trivy proteste.

## Documentation synchronisée

`tp05/README.md` contenait une **copie** du Role avec `pods/exec` : sans mise à jour,
l'élève aurait copié la version non durcie. Corrigé, avec un encadré expliquant pourquoi
ces deux droits sont refusés — plus formateur que leur absence silencieuse.

## Vérifications

- [x] `trivy config` : **261 → 255** misconfigurations HIGH/CRITICAL, 0 sur les 5 règles visées
- [x] Effet du fichier d'exceptions **mesuré avant/après** (257 → 255) — un chemin qui ne correspond pas serait ignoré en silence
- [x] `kubeconform -strict` sur les 6 manifests modifiés
- [x] YAML valides (manifests, workflow, fichier d'exceptions)
- [ ] Scrape Prometheus **non testé en cluster** — aucun cluster disponible ici. Le
      raisonnement sur cadvisor est vérifiable par lecture (adresse kubelet + chemin
      apiserver), mais mérite une exécution réelle du TP10 avant de s'y fier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
