### PR TITLE
fix(images): -180 CVE en remplaçant netshoot, et refus motivé de buildah

### DIFF
--- a/tp06/tekton/tasks/docker-build-task.yaml
+++ b/tp06/tekton/tasks/docker-build-task.yaml
@@ -17,7 +17,13 @@ spec:
       description: Chemin vers le Dockerfile
   steps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.23.2
+      # kaniko et non buildah, malgré les 112 CVE de son binaire Go : mesuré le
+      # 2026-07-27, buildah:v1.41 est à 0 CVE mais exige `seccompProfile: Unconfined`
+      # pour son unshare(CLONE_NEWUSER) — les capabilities et /dev/fuse n'y suffisent
+      # pas. Échanger des CVE non atteignables (un builder ne sert aucun trafic)
+      # contre la désactivation de seccomp serait une régression. kaniko construit
+      # sans daemon ni privilèges, ce qui est justement le sujet de ce TP.
+      image: gcr.io/kaniko-project/executor:v1.24.0
       workingDir: $(workspaces.source.path)
       env:
         - name: DOCKER_CONFIG

--- a/tp09/examples/taints-tolerations-examples.yaml
+++ b/tp09/examples/taints-tolerations-examples.yaml
@@ -60,7 +60,14 @@ spec:
   - operator: "Exists"
   containers:
   - name: admin
-    image: telemachlearning/netshoot:v0.16
+    # busybox et non netshoot : ce pod ne fait que `sleep infinity`, il sert à
+    # montrer qu'une toleration `operator: Exists` le laisse être planifié partout.
+    # netshoot embarque des dizaines d'outils réseau compilés en Go, soit ~174 CVE
+    # HIGH/CRITICAL dans des binaires qu'aucun exercice n'exécute ici. busybox
+    # fournit un shell, ping, nslookup et wget — 0 CVE.
+    # Pour un VRAI diagnostic réseau, netshoot reste l'outil de référence :
+    # voir tp09/exercices/exercice5-troubleshooting.md.
+    image: busybox:1.36
     command: ['sh', '-c', 'sleep infinity']
 
 ---

--- a/tp09/exercices/exercice3-isolation.yaml
+++ b/tp09/exercices/exercice3-isolation.yaml
@@ -300,7 +300,12 @@ spec:
     effect: "NoSchedule"
   containers:
   - name: debug
-    image: telemachlearning/netshoot:v0.16
+    # busybox et non netshoot : ce pod ne fait que `sleep infinity`, il démontre
+    # qu'une toleration `Exists` sur la clé `environment` permet d'être planifié
+    # sur tous les nœuds d'environnement. Aucun outil réseau n'est exécuté dessus.
+    # netshoot coûterait ~174 CVE HIGH/CRITICAL dans ses binaires Go embarqués ;
+    # busybox donne un shell, ping, nslookup et wget pour 0 CVE.
+    image: busybox:1.36
     command: ['sh', '-c', 'sleep infinity']
     resources:
       requests:


### PR DESCRIPTION
Deuxième passe sur les CVE d'images, après le constat qu'il en restait « beaucoup trop ».
**875 → 695 CVE HIGH/CRITICAL ouvertes (−180)**, dont 12 CRITICAL en moins.

Chaque piste a été mesurée avant d'être retenue ou écartée — y compris celles qui
paraissaient évidentes et qui se sont révélées mauvaises.

## netshoot → busybox : −174

`telemachlearning/netshoot:v0.16` était **le premier poste de CVE du dépôt** : 174
HIGH/CRITICAL dont 12 CRITICAL, toutes dans les binaires Go des dizaines d'outils réseau
qu'elle embarque.

Or les deux pods qui l'utilisaient — `super-admin-pod` et `admin-debug` — ne font que
`sleep infinity`. Ils démontrent qu'une toleration `operator: Exists` permet d'être
planifié sur des nœuds taintés. **Le sujet est le scheduling, pas le réseau** : aucun
exercice n'exécute le moindre outil de netshoot. Même schéma que le Job TensorFlow
abandonné le 2026-07-17.

`busybox:1.36` fournit un shell, `ping`, `nslookup` et `wget` pour **0 CVE**, et figurait
déjà parmi les images du dépôt.

netshoot reste enseignée là où elle sert vraiment : la commande `kubectl run netshoot`
de `tp09/exercices/exercice5-troubleshooting.md` est inchangée.

## kaniko v1.23.2 → v1.24.0 : −6, et un refus documenté

Gain modeste (118 → 112 CVE de binaire Go, 0 CVE OS avant comme après, la barrière reste
verte). L'essentiel de ce commit est ailleurs : **documenter pourquoi kaniko reste**,
pour que la question ne soit pas rouverte à chaque scan.

`quay.io/buildah/stable:v1.41` est mesurée à **0 CVE** et semble donc être le
remplacement évident. Elle ne l'est pas. Testé en local le 2026-07-27 :

| Configuration | Résultat |
|---|---|
| aucun privilège | ❌ `unshare(CLONE_NEWUSER): Operation not permitted` |
| `SETUID` + `SETGID` + `SETFCAP` | ❌ identique |
| capabilities + `/dev/fuse` | ❌ identique |
| `seccomp=unconfined` | ✅ |
| `privileged` | ✅ |

buildah exige donc `seccompProfile: Unconfined` — que Trivy signale (`KSV-0104`).
L'échange serait : 112 CVE dans le binaire Go d'un builder, **non atteignables** puisqu'il
ne sert aucun trafic, contre la désactivation d'une protection runtime réelle sur le pod
de build. Mauvais échange. Et kaniko construit sans daemon ni privilèges, ce qui est
précisément ce que le TP6 enseigne.

## Les pistes écartées, mesurées

| Image | CVE | Alternative testée | Verdict |
|---|---|---|---|
| `wordpress` | 163 | Bitnami **retiré** de Docker Hub, pas d'alpine officielle | plancher |
| `kibana` + `elasticsearch` | 182 | ES `9.1.5` = **103** contre 85 | monter aggrave |
| `cassandra:4.1` | 57 | `5.0` = **76** contre 57 | monter aggrave |
| `fluentd` ×2 | 58 | durcissement déjà construit et mesuré, sans gain | plancher |

## Ce qui reste, et pourquoi

Les ~695 CVE restantes sont des binaires Go et Java compilés dans des images tierces
(Elasticsearch, Kibana, Cassandra, WordPress, kaniko). Elles ne partiront que si l'amont
recompile, et leur nombre croît d'environ 5-6 par mois et par binaire simplement parce
que le build vieillit — sans qu'aucun risque nouveau n'apparaisse.

C'est exactement ce que la barrière CI écarte depuis la PR #132 : **ce qui est
actionnable est déjà à zéro**. Un chiffre élevé n'est pas ici un chiffre négligé, c'est
un chiffre sur lequel ce dépôt n'a pas de prise.

## Vérifications

- [x] 31 → 30 images scannées, netshoot sortie du périmètre
- [x] `kaniko:v1.24.0` : **0 CVE OS** — la barrière reste verte
- [x] `kubeconform -strict` sur les 3 manifests modifiés
- [x] Comportement de buildah **testé en local** à 5 niveaux de privilèges, pas déduit
- [ ] Les manifests tp09 **non appliqués sur un cluster** — aucun cluster ici. Le
      changement se limite à l'image d'un pod qui dort, mais l'exercice 3 mérite une
      exécution réelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
