### PR TITLE
fix(tp09): durcir les 29 workloads des exemples (87 misconfigurations)

### DIFF
--- a/tp09/examples/node-affinity-examples.yaml
+++ b/tp09/examples/node-affinity-examples.yaml
@@ -1,4 +1,9 @@
 # Exemples d'affinité de nœuds pour le TP9
+#
+# 🔐 Les pods portent un securityContext complet bien que le sujet soit le
+# SCHEDULING : un exemple applicable tel quel ne doit pas enseigner une régression
+# de sécurité par omission (.claude/SECURITY.md). Chaque readOnlyRootFilesystem
+# s'accompagne des emptyDir que l'image exige réellement pour démarrer.
 
 ---
 # Exemple 1 : Affinité stricte (required) - Production seulement
@@ -29,9 +34,28 @@ spec:
                 operator: In
                 values:
                 - production
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101       # nginx
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: webapp
         image: nginx:alpine
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        # nginx écrit son cache et son PID : sans ces volumes, il ne démarre pas
+        # en système de fichiers racine en lecture seule.
+        - name: cache
+          mountPath: /var/cache/nginx
+        - name: run
+          mountPath: /var/run
         resources:
           requests:
             memory: "128Mi"
@@ -39,6 +63,11 @@ spec:
           limits:
             memory: "256Mi"
             cpu: "200m"
+      volumes:
+      - name: cache
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
 
 ---
 # Exemple 2 : Affinité préférée (preferred) - Préfère SSD
@@ -75,13 +104,35 @@ spec:
                 operator: In
                 values:
                 - zone-a
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999       # redis
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: redis
         image: redis:alpine
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        # Redis écrit son dump RDB dans /data, même sans persistance configurée.
+        - name: data
+          mountPath: /data
         resources:
           requests:
             memory: "256Mi"
             cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      volumes:
+      - name: data
+        emptyDir: {}
 
 ---
 # Exemple 3 : Combinaison required + preferred
@@ -132,9 +183,25 @@ spec:
                 operator: In
                 values:
                 - high-performance
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
+        # Image fictive : voir .github/image-scan-ignore.txt.
         image: myapp:1.0.0
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "512Mi"
@@ -142,6 +209,9 @@ spec:
           limits:
             memory: "1Gi"
             cpu: "1"
+      volumes:
+      - name: tmp
+        emptyDir: {}
 
 ---
 # Exemple 4 : Opérateurs multiples
@@ -177,10 +247,32 @@ spec:
                 operator: Gt
                 values:
                 - "3"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534     # nobody, l'utilisateur des images Prometheus
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: prometheus
         image: prom/prometheus:v3
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        # Prometheus écrit sa base TSDB dans /prometheus.
+        - name: data
+          mountPath: /prometheus
         resources:
           requests:
             memory: "2Gi"
             cpu: "1"
+          limits:
+            memory: "4Gi"
+            cpu: "2"
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/tp09/examples/pod-affinity-examples.yaml
+++ b/tp09/examples/pod-affinity-examples.yaml
@@ -22,15 +22,36 @@ spec:
         app: redis
         tier: cache
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: redis
         image: redis:alpine
         ports:
         - containerPort: 6379
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: data
+          mountPath: /data
         resources:
           requests:
             memory: "256Mi"
             cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      volumes:
+      - name: data
+        emptyDir: {}
 
 ---
 # Web server qui doit être sur le même nœud que Redis
@@ -67,15 +88,40 @@ spec:
                 values:
                 - cache
             topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: nginx
         image: nginx:alpine
         ports:
         - containerPort: 80
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: cache
+          mountPath: /var/cache/nginx
+        - name: run
+          mountPath: /var/run
         resources:
           requests:
             memory: "128Mi"
             cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+      volumes:
+      - name: cache
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
 
 ---
 # Exemple 2 : Pod Anti-Affinity - Haute disponibilité
@@ -106,11 +152,26 @@ spec:
                 values:
                 - critical-service
             topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: service
         image: myapp:1.0.0
         ports:
         - containerPort: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "256Mi"
@@ -118,6 +179,9 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "500m"
+      volumes:
+      - name: tmp
+        emptyDir: {}
 
 ---
 # Exemple 3 : Anti-Affinity préférée (soft)
@@ -148,13 +212,34 @@ spec:
                   values:
                   - worker-service
               topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: worker
         image: worker:v1
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "128Mi"
             cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+      volumes:
+      - name: tmp
+        emptyDir: {}
 
 ---
 # Exemple 4 : Architecture 3-tiers complète avec affinités
@@ -203,14 +288,42 @@ spec:
                 values:
                 - database
             topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        fsGroup: 70
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: postgres
         image: postgres:15-alpine
         ports:
         - containerPort: 5432
         env:
+        # Jamais de mot de passe en clair, même dans un exemple : c'est la ligne
+        # que l'élève copiera.
         - name: POSTGRES_PASSWORD
-          value: "changeme"
+          valueFrom:
+            secretKeyRef:
+              name: postgres-secret
+              key: password
+        # PGDATA doit être un SOUS-répertoire du volume monté : initdb exige un
+        # répertoire vide, or un point de montage ne l'est jamais tout à fait.
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+        - name: run
+          mountPath: /var/run/postgresql
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "1Gi"
@@ -218,6 +331,13 @@ spec:
           limits:
             memory: "2Gi"
             cpu: "1"
+      volumes:
+      - name: data
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 
 ---
 # Tier 2 : Backend (proche de la DB, réparti entre eux)
@@ -273,15 +393,36 @@ spec:
                   values:
                   - backend
               topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: backend
         image: backend:v2
         ports:
         - containerPort: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "512Mi"
             cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+      volumes:
+      - name: tmp
+        emptyDir: {}
 
 ---
 # Tier 3 : Frontend (proche du backend)
@@ -337,15 +478,36 @@ spec:
                   values:
                   - frontend
               topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: frontend
         image: frontend:v2
         ports:
         - containerPort: 80
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "128Mi"
             cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+      volumes:
+      - name: tmp
+        emptyDir: {}
 
 ---
 # Exemple 5 : topologyKey par zone (répartition géographique)
@@ -386,10 +548,31 @@ spec:
                   values:
                   - geo-distributed
               topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
         image: myapp:1.0.0
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "256Mi"
             cpu: "200m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/tp09/examples/poddisruptionbudget-examples.yaml
+++ b/tp09/examples/poddisruptionbudget-examples.yaml
@@ -1,4 +1,9 @@
 # Exemples de PodDisruptionBudgets (PDB) pour le TP9
+#
+# 🔐 securityContext complet sur tous les pods bien que le sujet soit la
+# DISPONIBILITÉ (.claude/SECURITY.md) : un exemple applicable tel quel ne doit pas
+# enseigner une régression par omission. Chaque readOnlyRootFilesystem est
+# accompagné des emptyDir que l'image exige pour démarrer.
 
 ---
 # Exemple 1 : minAvailable - Nombre minimum de pods disponibles
@@ -84,11 +89,26 @@ spec:
         app: myapp
         tier: backend
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: myapp
         image: myapp:v2
         ports:
         - containerPort: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "256Mi"
@@ -108,6 +128,9 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 5
+      volumes:
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: Service
@@ -149,6 +172,12 @@ spec:
       labels:
         app: etcd
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: etcd
         image: quay.io/coreos/etcd:v3.5.32
@@ -157,10 +186,28 @@ spec:
           name: client
         - containerPort: 2380
           name: peer
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        # /var/lib/etcd est le WorkingDir de l'image : c'est là qu'etcd crée son
+        # data-dir. Sans ce volume, il ne peut rien écrire en racine read-only.
+        - name: data
+          mountPath: /var/lib/etcd
         resources:
           requests:
             memory: "1Gi"
             cpu: "500m"
+          limits:
+            memory: "2Gi"
+            cpu: "1"
+      volumes:
+      # emptyDir : cet exemple illustre les PDB, pas la persistance d'etcd.
+      - name: data
+        emptyDir: {}
 ---
 # PDB pour maintenir le quorum (minimum 3 sur 5)
 apiVersion: policy/v1
@@ -191,13 +238,34 @@ spec:
         app: batch-worker
         role: processing
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: worker
         image: batch-worker:v1
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "512Mi"
             cpu: "500m"
+          limits:
+            memory: "1Gi"
+            cpu: "1"
+      volumes:
+      - name: tmp
+        emptyDir: {}
 ---
 # Autorise jusqu'à 30% d'indisponibilité
 apiVersion: policy/v1
@@ -239,11 +307,26 @@ spec:
                 values:
                 - critical-api
             topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: api
         image: critical-api:v3
         ports:
         - containerPort: 443
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "1Gi"
@@ -251,6 +334,9 @@ spec:
           limits:
             memory: "2Gi"
             cpu: "2"
+      volumes:
+      - name: tmp
+        emptyDir: {}
 ---
 # PDB très strict - maximum 1 pod indisponible à la fois
 apiVersion: policy/v1
@@ -284,13 +370,34 @@ spec:
         component: frontend
         version: v2
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: frontend
         image: frontend:v2
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "256Mi"
             cpu: "200m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      volumes:
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -309,13 +416,34 @@ spec:
         component: backend
         version: v2
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: backend
         image: backend:v2
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "512Mi"
             cpu: "500m"
+          limits:
+            memory: "1Gi"
+            cpu: "1"
+      volumes:
+      - name: tmp
+        emptyDir: {}
 ---
 # PDB pour le frontend
 apiVersion: policy/v1
@@ -384,13 +512,34 @@ spec:
         app: monitoring
         critical: "false"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: agent
         image: monitoring-agent:1.0.0
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "128Mi"
             cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+      volumes:
+      - name: tmp
+        emptyDir: {}
 ---
 # Ce PDB ne bloquera pas les drains car DaemonSet
 # mais documente l'intention

--- a/tp09/examples/taints-tolerations-examples.yaml
+++ b/tp09/examples/taints-tolerations-examples.yaml
@@ -1,9 +1,20 @@
 # Exemples de Taints et Tolerations pour le TP9
-
+#
 # Pour appliquer les taints, utilisez ces commandes :
 # kubectl taint nodes worker1 dedicated=database:NoSchedule
 # kubectl taint nodes worker2 gpu=nvidia:NoSchedule
 # kubectl taint nodes worker3 maintenance=true:NoExecute
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# 🔐 Tous les pods ci-dessous portent un securityContext complet, même si le
+# sujet du fichier est le SCHEDULING. C'est la règle du dépôt (.claude/SECURITY.md) :
+# un exemple qu'on peut appliquer tel quel doit être applicable SANS régression de
+# sécurité, sinon il enseigne le mauvais réflexe par omission.
+#
+# Chaque `readOnlyRootFilesystem: true` s'accompagne des emptyDir que l'image exige
+# vraiment pour démarrer. Un durcissement qui passe le `--dry-run` mais produit un
+# CrashLoopBackOff serait pire que pas de durcissement du tout.
+# ─────────────────────────────────────────────────────────────────────────────
 
 ---
 # Exemple 1 : Toleration simple avec Equal
@@ -19,12 +30,41 @@ spec:
     operator: "Equal"
     value: "database"
     effect: "NoSchedule"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 70        # postgres, dans les images Alpine
+    fsGroup: 70
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: postgres
     image: postgres:15-alpine
     env:
+    # Jamais de mot de passe en clair, même dans un exemple : c'est la ligne que
+    # l'élève copiera. Créer le secret avec :
+    #   kubectl create secret generic postgres-secret --from-literal=password=...
     - name: POSTGRES_PASSWORD
-      value: "mysecretpassword"
+      valueFrom:
+        secretKeyRef:
+          name: postgres-secret
+          key: password
+    # PGDATA doit être un SOUS-répertoire du volume monté : initdb exige un
+    # répertoire vide, or un point de montage ne l'est jamais tout à fait.
+    - name: PGDATA
+      value: /var/lib/postgresql/data/pgdata
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+        - ALL
+    volumeMounts:
+    - name: data
+      mountPath: /var/lib/postgresql/data
+    - name: run
+      mountPath: /var/run/postgresql
+    - name: tmp
+      mountPath: /tmp
     resources:
       requests:
         memory: "1Gi"
@@ -32,6 +72,14 @@ spec:
       limits:
         memory: "2Gi"
         cpu: "1"
+  volumes:
+  # emptyDir et non PVC : cet exemple illustre le scheduling, pas la persistance.
+  - name: data
+    emptyDir: {}
+  - name: run
+    emptyDir: {}
+  - name: tmp
+    emptyDir: {}
 
 ---
 # Exemple 2 : Toleration avec Exists (tolère toute valeur)
@@ -44,10 +92,29 @@ spec:
   - key: "dedicated"
     operator: "Exists"
     effect: "NoSchedule"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534     # nobody
+    fsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: admin
     image: busybox:1.36
     command: ['sh', '-c', 'sleep 3600']
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+        - ALL
+    resources:
+      requests:
+        memory: "16Mi"
+        cpu: "10m"
+      limits:
+        memory: "64Mi"
+        cpu: "100m"
 
 ---
 # Exemple 3 : Tolérer tous les taints (super admin)
@@ -58,6 +125,12 @@ metadata:
 spec:
   tolerations:
   - operator: "Exists"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    fsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: admin
     # busybox et non netshoot : ce pod ne fait que `sleep infinity`, il sert à
@@ -69,6 +142,19 @@ spec:
     # voir tp09/exercices/exercice5-troubleshooting.md.
     image: busybox:1.36
     command: ['sh', '-c', 'sleep infinity']
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+        - ALL
+    resources:
+      requests:
+        memory: "16Mi"
+        cpu: "10m"
+      limits:
+        memory: "64Mi"
+        cpu: "100m"
 
 ---
 # Exemple 4 : Deployment pour nœuds dédiés base de données
@@ -98,6 +184,12 @@ spec:
         operator: "Equal"
         value: "database"
         effect: "NoSchedule"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        fsGroup: 70
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: postgres
         image: postgres:15-alpine
@@ -109,6 +201,21 @@ spec:
             secretKeyRef:
               name: postgres-secret
               key: password
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+        - name: run
+          mountPath: /var/run/postgresql
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "2Gi"
@@ -116,6 +223,13 @@ spec:
           limits:
             memory: "4Gi"
             cpu: "2"
+      volumes:
+      - name: data
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 
 ---
 # Exemple 5 : Job GPU avec toleration
@@ -139,6 +253,12 @@ spec:
         operator: "Equal"
         value: "true"
         effect: "NoSchedule"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: ml-training
         # Image générique : ce qui fait de ce Job une charge GPU, c'est le
@@ -147,11 +267,27 @@ spec:
         # ~400 CVE dont ~182 sans correctif amont (voir docker/hardened/README.md).
         image: python:3.13-alpine
         command: ["python", "train.py"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        # Python écrit ses caches de bytecode et ses fichiers temporaires.
+        - name: tmp
+          mountPath: /tmp
         resources:
           limits:
             nvidia.com/gpu: 1
             memory: "8Gi"
             cpu: "4"
+          requests:
+            memory: "4Gi"
+            cpu: "2"
+      volumes:
+      - name: tmp
+        emptyDir: {}
 
 ---
 # Exemple 6 : NoExecute avec tolerationSeconds
@@ -167,13 +303,40 @@ spec:
     value: "true"
     effect: "NoExecute"
     tolerationSeconds: 3600
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 101       # nginx, dans les images Alpine
+    fsGroup: 101
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: app
     image: nginx:alpine
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+        - ALL
+    volumeMounts:
+    # nginx écrit son cache et son PID au démarrage : sans ces deux volumes, le
+    # master refuse de démarrer en lecture seule.
+    - name: cache
+      mountPath: /var/cache/nginx
+    - name: run
+      mountPath: /var/run
     resources:
       requests:
         memory: "128Mi"
         cpu: "100m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+  volumes:
+  - name: cache
+    emptyDir: {}
+  - name: run
+    emptyDir: {}
 
 ---
 # Exemple 7 : Deployment avec tolerations multiples
@@ -206,13 +369,37 @@ spec:
       - key: "gpu"
         operator: "Exists"
         effect: "PreferNoSchedule"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
+        # Image fictive : remplacer par la vôtre. Elle est listée dans
+        # .github/image-scan-ignore.txt, sans quoi le scan hebdomadaire échouerait
+        # en tentant de la tirer.
         image: myapp:1.0.0
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "256Mi"
             cpu: "200m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      volumes:
+      - name: tmp
+        emptyDir: {}
 
 ---
 # Exemple 8 : DaemonSet avec toleration pour tous les nœuds
@@ -245,13 +432,33 @@ spec:
         effect: NoExecute
       - operator: Exists
         effect: NoSchedule
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000      # fluent
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: fluentd
         # Fluentd ne publie plus de variante alpine : les tags actuels sont debian.
         image: fluent/fluentd:v1.19.3-debian-2.2
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
+        # Lecture seule : un collecteur de logs LIT /var/log, il n'a aucune raison
+        # d'y écrire — et un hostPath inscriptible sur un nœud est une porte ouverte.
         - name: varlog
           mountPath: /var/log
+          readOnly: true
+        # Fluentd écrit ses buffers de position et ses fichiers temporaires.
+        - name: fluentd-buffer
+          mountPath: /fluentd/log
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "200Mi"
@@ -263,6 +470,10 @@ spec:
       - name: varlog
         hostPath:
           path: /var/log
+      - name: fluentd-buffer
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 
 ---
 # Exemple 9 : StatefulSet pour nœuds SSD avec affinity + toleration
@@ -305,6 +516,12 @@ spec:
         operator: "Equal"
         value: "elasticsearch"
         effect: "NoSchedule"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000      # elasticsearch
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: elasticsearch
         image: docker.elastic.co/elasticsearch/elasticsearch:8.17.7
@@ -316,6 +533,21 @@ spec:
         env:
         - name: discovery.type
           value: "single-node"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        # Elasticsearch écrit ses index, ses logs et son fichier de config généré
+        # au démarrage. Les trois sont indispensables en lecture seule.
+        - name: data
+          mountPath: /usr/share/elasticsearch/data
+        - name: logs
+          mountPath: /usr/share/elasticsearch/logs
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "2Gi"
@@ -323,6 +555,15 @@ spec:
           limits:
             memory: "4Gi"
             cpu: "2"
+      volumes:
+      # emptyDir et non volumeClaimTemplates : cet exemple illustre le placement
+      # des pods, pas la persistance des données.
+      - name: data
+        emptyDir: {}
+      - name: logs
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 
 ---
 # Exemple 10 : CronJob qui tolère les nœuds de maintenance
@@ -345,8 +586,15 @@ spec:
           - key: "maintenance"
             operator: "Exists"
             effect: "NoExecute"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
           containers:
           - name: backup
+            # Image fictive : voir .github/image-scan-ignore.txt.
             image: backup-tool:1.0.0
             command: ["/bin/sh"]
             args:
@@ -355,7 +603,22 @@ spec:
               echo "Starting backup..."
               # Script de backup ici
               echo "Backup completed"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                - ALL
+            volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             resources:
               requests:
                 memory: "512Mi"
                 cpu: "250m"
+              limits:
+                memory: "1Gi"
+                cpu: "500m"
+          volumes:
+          - name: tmp
+            emptyDir: {}


### PR DESCRIPTION
Premier lot du chantier `KSV-0118` / `KSV-0014`. `tp09/examples/` concentrait **87 des
255** misconfigurations du dépôt : **255 → 168**.

29 workloads durcis dans 4 fichiers, chacun recevant le `securityContext` du template
`.claude/templates/secure-deployment.yaml`.

## Le point délicat : durcir sans casser

Ces exemples ne sont testés qu'en `kubectl apply --dry-run=client`, **qui ne monte aucun
volume**. Un `readOnlyRootFilesystem: true` posé sans les `emptyDir` correspondants
passerait donc la CI sans broncher — et produirait un `CrashLoopBackOff` chez l'élève qui
applique le manifest. Ce serait pire que pas de durcissement du tout.

UID et volumes déterminés **image par image**, jamais extrapolés :

| Image | UID | Volumes requis |
|---|---|---|
| `postgres:15-alpine` | 70 | data + `/var/run/postgresql` + `/tmp`, et `PGDATA` en sous-répertoire |
| `nginx:alpine` | 101 | `/var/cache/nginx` + `/var/run` |
| `redis:alpine` | 999 | `/data` — le dump RDB est écrit même sans persistance configurée |
| `prom/prometheus:v3` | 65534 | `/prometheus` (TSDB) |
| `elasticsearch:8.17.7` | 1000 | data + logs + `/tmp` |
| `fluentd` | 1000 | `/fluentd/log` + `/tmp` |
| `etcd:v3.5.32` | 1000 | `/var/lib/etcd` |
| `busybox` / `python:3.13-alpine` | 65534 | `/tmp` |

Pour etcd, `docker inspect` a montré `User=0` et `WorkingDir=/var/lib/etcd/` : c'est là
qu'il crée son data-dir, donc là qu'il faut le volume. Vérifié plutôt que supposé —
l'image n'a même pas de shell pour aller regarder.

`PGDATA` est défini partout où un volume est monté sur `/var/lib/postgresql/data` : sans
ça, `initdb` refuse de démarrer sur un répertoire qui n'est pas tout à fait vide. C'est
la leçon de la session 2025-12-17, déjà payée une fois sur le TP10.

## Corrections de sécurité au-delà de Trivy

- **Deux mots de passe en clair** — `"mysecretpassword"` dans `taints-tolerations` et
  `"changeme"` dans `pod-affinity`. `.claude/SECURITY.md` l'interdit explicitement, et
  c'est la ligne que l'élève copiera. Remplacés par un `secretKeyRef`.
- **Le `hostPath` `/var/log`** du DaemonSet fluentd passe en `readOnly: true` : un
  collecteur de logs lit, il n'a aucune raison d'écrire sur le système de fichiers du
  nœud. Aucune règle Trivy ne le signalait.
- Des `limits` ajoutées là où seules des `requests` existaient.

## Vérifications

- [x] `trivy config` : **87 → 0** sur `tp09/examples/`, dépôt à 168
- [x] `kubeconform -strict` valide les 4 fichiers
- [x] Aucune image nouvelle dans le périmètre de scan (les fictives sont couvertes par
      les motifs de `.github/image-scan-ignore.txt`, vérifié avec `extract-images.py`)
- [ ] **Non appliqué sur un cluster** — aucun cluster joignable ici, et c'est précisément
      la vérification qui manque : les volumes ont été déduits de la documentation et de
      `docker inspect`, pas d'un démarrage réel. Les workloads à surveiller en priorité
      sont postgres, elasticsearch et etcd.

## Reste à faire

**168 alertes** sur les autres TP : `KSV-0118` (108) et `KSV-0014` (60). Même méthode,
lot par lot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
