### PR TITLE
fix(tp06): durcir les workloads et documenter les patchs Kustomize (43 alertes)

### DIFF
--- a/.trivyignore-manifests.yaml
+++ b/.trivyignore-manifests.yaml
@@ -26,6 +26,14 @@
 #
 # Format : https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids
 
+# DEUXIÈME CRITÈRE D'ENTRÉE, ajouté le 2026-07-27 : un fichier qui N'EST PAS un
+# manifest complet. Trivy analyse chaque fichier isolément ; un patch Kustomize,
+# lui, n'a de sens que fusionné avec sa base. L'alerte porte alors sur un objet
+# qui n'existe nulle part — ni dans le dépôt, ni dans le cluster.
+#
+# Ce critère n'est recevable que VÉRIFIÉ : il faut montrer que le résultat de
+# `kustomize build` est bien durci. Sinon c'est un blanc-seing.
+
 misconfigurations:
   # ── tp05/05-clusterrole-secret-reader.yaml ──
   # Ce fichier existe pour démontrer un ClusterRole, et le fait sur l'exemple le
@@ -58,3 +66,33 @@ misconfigurations:
       Démonstration pédagogique du type de Service ExternalName (TP8 - Réseau).
       Le manifest ne contient que cet objet : respecter la règle reviendrait à
       supprimer l'exemple.
+
+  # ── tp06/07-gitops-structure/overlays/*/patch-deployment.yaml ──
+  # Patchs Kustomize (`patchesStrategicMerge`), pas des manifests déployables : ils
+  # ne redéclarent que l'image et les ressources, tout le reste vient de la base.
+  #
+  # Vérifié le 2026-07-27 avec `kustomize build` sur les trois overlays : le
+  # Deployment produit porte bien le securityContext du pod ET du conteneur, les
+  # volumeMounts et les volumes hérités de `base/deployment.yaml`. Dupliquer ces
+  # blocs dans chaque patch serait redondant, et enseignerait à l'élève l'inverse
+  # de ce que Kustomize sert à faire.
+  #
+  # Pour le revérifier :
+  #   kustomize build tp06/07-gitops-structure/overlays/dev | grep -A4 securityContext
+  - id: KSV-0118
+    paths:
+      - "tp06/07-gitops-structure/overlays/dev/patch-deployment.yaml"
+      - "tp06/07-gitops-structure/overlays/staging/patch-deployment.yaml"
+      - "tp06/07-gitops-structure/overlays/production/patch-deployment.yaml"
+    statement: >-
+      Patch Kustomize partiel, pas un manifest complet. Le securityContext vient de
+      base/deployment.yaml et est présent dans le résultat de `kustomize build`,
+      vérifié sur les trois overlays.
+  - id: KSV-0014
+    paths:
+      - "tp06/07-gitops-structure/overlays/dev/patch-deployment.yaml"
+      - "tp06/07-gitops-structure/overlays/staging/patch-deployment.yaml"
+      - "tp06/07-gitops-structure/overlays/production/patch-deployment.yaml"
+    statement: >-
+      Patch Kustomize partiel : readOnlyRootFilesystem est déclaré dans la base et
+      présent dans le résultat de `kustomize build`, vérifié sur les trois overlays.

--- a/tp06/02-ingress/01-app-deployment.yaml
+++ b/tp06/02-ingress/01-app-deployment.yaml
@@ -12,11 +12,42 @@ spec:
       labels:
         app: web-app
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101       # nginx
+        fsGroup: 101         # rend les emptyDir ci-dessous inscriptibles par nginx
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: nginx
         image: nginx:alpine
         ports:
         - containerPort: 80
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        # nginx écrit son cache et son PID au démarrage : sans ces volumes il
+        # refuse de démarrer en racine lecture seule.
+        - name: cache
+          mountPath: /var/cache/nginx
+        - name: run
+          mountPath: /var/run
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "200m"
+      volumes:
+      - name: cache
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/tp06/02-ingress/03-multi-service-ingress.yaml
+++ b/tp06/02-ingress/03-multi-service-ingress.yaml
@@ -12,6 +12,12 @@ spec:
       labels:
         app: api
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534     # nobody
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: api
         image: hashicorp/http-echo:0.2.3
@@ -19,6 +25,19 @@ spec:
         - "-text=API Response"
         ports:
         - containerPort: 5678
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
 ---
 apiVersion: v1
 kind: Service
@@ -45,11 +64,42 @@ spec:
       labels:
         app: frontend
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101       # nginx
+        fsGroup: 101         # rend les emptyDir ci-dessous inscriptibles par nginx
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: frontend
         image: nginx:alpine
         ports:
         - containerPort: 80
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        # nginx écrit son cache et son PID au démarrage : sans ces volumes il
+        # refuse de démarrer en racine lecture seule.
+        - name: cache
+          mountPath: /var/cache/nginx
+        - name: run
+          mountPath: /var/run
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "200m"
+      volumes:
+      - name: cache
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/tp06/03-deployment-strategies/06-rolling-update.yaml
+++ b/tp06/03-deployment-strategies/06-rolling-update.yaml
@@ -18,12 +18,31 @@ spec:
         app: rolling-app
         version: v1
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534     # nobody
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
         image: hashicorp/http-echo:0.2.3
         args: ["-text=Version 1"]
         ports:
         - containerPort: 5678
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
         readinessProbe:
           httpGet:
             path: /

--- a/tp06/03-deployment-strategies/07-blue-green.yaml
+++ b/tp06/03-deployment-strategies/07-blue-green.yaml
@@ -15,12 +15,31 @@ spec:
         app: myapp
         version: blue
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534     # nobody
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
         image: hashicorp/http-echo:0.2.3
         args: ["-text=Blue Version"]
         ports:
         - containerPort: 5678
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
 ---
 # Green deployment
 apiVersion: apps/v1
@@ -39,12 +58,31 @@ spec:
         app: myapp
         version: green
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534     # nobody
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
         image: hashicorp/http-echo:0.2.3
         args: ["-text=Green Version"]
         ports:
         - containerPort: 5678
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
 ---
 # Service pointant vers blue
 apiVersion: v1

--- a/tp06/03-deployment-strategies/08-canary.yaml
+++ b/tp06/03-deployment-strategies/08-canary.yaml
@@ -15,12 +15,31 @@ spec:
         app: myapp
         track: stable
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534     # nobody
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
         image: hashicorp/http-echo:0.2.3
         args: ["-text=Stable Version"]
         ports:
         - containerPort: 5678
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
 ---
 # Canary version (10%)
 apiVersion: apps/v1
@@ -39,12 +58,31 @@ spec:
         app: myapp
         track: canary
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534     # nobody
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
         image: hashicorp/http-echo:0.2.3
         args: ["-text=Canary Version"]
         ports:
         - containerPort: 5678
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
 ---
 # Service commun
 apiVersion: v1

--- a/tp06/03-deployment-strategies/09-ab-testing.yaml
+++ b/tp06/03-deployment-strategies/09-ab-testing.yaml
@@ -14,12 +14,31 @@ spec:
         app: myapp
         version: v1
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534     # nobody
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
         image: hashicorp/http-echo:0.2.3
         args: ["-text=Version 1"]
         ports:
         - containerPort: 5678
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -37,12 +56,31 @@ spec:
         app: myapp
         version: v2
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534     # nobody
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
         image: hashicorp/http-echo:0.2.3
         args: ["-text=Version 2 - New Feature"]
         ports:
         - containerPort: 5678
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
 ---
 apiVersion: v1
 kind: Service

--- a/tp06/04-production-best-practices/12-health-checks.yaml
+++ b/tp06/04-production-best-practices/12-health-checks.yaml
@@ -12,11 +12,25 @@ spec:
       labels:
         app: production-app
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101       # nginx
+        fsGroup: 101         # rend les emptyDir ci-dessous inscriptibles par nginx
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
         image: nginx:alpine
         ports:
         - containerPort: 80
+        volumeMounts:
+        # readOnlyRootFilesystem etait deja declare plus bas, mais SANS ces volumes :
+        # nginx echouait sur mkdir() /var/cache/nginx/client_temp et le pod ne
+        # demarrait pas. Un durcissement incomplet est une panne, pas une securite.
+        - name: cache
+          mountPath: /var/cache/nginx
+        - name: run
+          mountPath: /var/run
 
         # Startup probe - vérifie le démarrage initial
         startupProbe:
@@ -65,6 +79,12 @@ spec:
           capabilities:
             drop:
             - ALL
+
+      volumes:
+      - name: cache
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
 ---
 # Service pour exposer production-app
 apiVersion: v1

--- a/tp06/07-gitops-structure/base/deployment.yaml
+++ b/tp06/07-gitops-structure/base/deployment.yaml
@@ -12,11 +12,30 @@ spec:
       labels:
         app: my-app
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101       # nginx
+        fsGroup: 101         # rend les emptyDir ci-dessous inscriptibles par nginx
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
         image: nginx:alpine
         ports:
         - containerPort: 80
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        # nginx écrit son cache et son PID au démarrage : sans ces volumes il
+        # refuse de démarrer en racine lecture seule.
+        - name: cache
+          mountPath: /var/cache/nginx
+        - name: run
+          mountPath: /var/run
         resources:
           requests:
             memory: "64Mi"
@@ -24,3 +43,8 @@ spec:
           limits:
             memory: "128Mi"
             cpu: "200m"
+      volumes:
+      - name: cache
+        emptyDir: {}
+      - name: run
+        emptyDir: {}


### PR DESCRIPTION
Deuxième lot du chantier `KSV-0118` / `KSV-0014` : **tp06 passe de 43 à 0**, le dépôt de
**168 à 125**.

34 alertes corrigées, 9 exceptées.

## 34 corrigées, sur 3 images seulement

Ce petit nombre d'images a permis de **vérifier chaque cas plutôt que de l'extrapoler** :

| Image | Workloads | UID | Volumes |
|---|---|---|---|
| `hashicorp/http-echo:0.2.3` | 8 | 65534 | **aucun** |
| `nginx:alpine` / `telemachlearning/nginx` | 5 | 101 | `/var/cache/nginx` + `/var/run` |

`http-echo` a été testé en conteneur avec `--user 65534 --read-only` : il démarre et
répond 200 **sans aucun volume**, étant un binaire statique qui n'écrit rien. Lui coller
un `emptyDir /tmp` par réflexe aurait été du bruit.

## Une vérification qui valide la PR #137

nginx en `--read-only` avec des **tmpfs Docker** échoue sur
`mkdir() "/var/cache/nginx/client_temp"` — parce qu'un tmpfs appartient à `root:root`.
Avec un volume appartenant à l'UID 101 — ce que Kubernetes fait via `fsGroup` sur un
`emptyDir` — il répond 200.

C'est la confirmation que le pattern appliqué au tp09 tient : **`fsGroup` n'est pas
décoratif, il conditionne le démarrage**.

## 🐛 Bug corrigé

`04-production-best-practices/12-health-checks.yaml` déclarait
`readOnlyRootFilesystem: true` sur nginx **sans aucun volume**. Ce pod ne pouvait pas
démarrer.

Personne ne l'avait vu parce que ces manifests ne sont validés qu'en `--dry-run`, qui ne
monte rien — et le fichier s'appelle « production-best-practices ». C'est exactement le
risque annoncé dans la PR #137 : un durcissement incomplet est une panne, pas une
sécurité.

## 9 exceptées : les patchs Kustomize

Les 3 overlays GitOps ne sont **pas des manifests déployables** : ils ne redéclarent que
l'image et les ressources. Trivy les analyse isolément et signale un `securityContext`
absent d'un objet qui n'existe nulle part.

Vérifié avec `kustomize build` sur les trois overlays — le Deployment produit porte le
`securityContext` du pod **et** du conteneur, les `volumeMounts` et les `volumes` hérités
de `base/deployment.yaml`, qui est durci dans cette PR. Dupliquer ces blocs dans chaque
patch enseignerait à l'élève l'inverse de ce que Kustomize sert à faire.

`.trivyignore-manifests.yaml` gagne donc un **second critère d'entrée**, explicitement
délimité : *un fichier qui n'est pas un manifest complet*. Recevable seulement s'il est
vérifié, et la commande de revérification est écrite dans le fichier :

```bash
kustomize build tp06/07-gitops-structure/overlays/dev | grep -A4 securityContext
```

## ⚠️ Piège reconfirmé sur les exceptions

Le `paths:` d'une exception est **relatif au chemin scanné**. Testée sur `tp06/` ou sur
le fichier seul, l'exception ne s'applique pas — et Trivy n'émet **aucun avertissement**.
Elle ne prend effet que depuis la racine, ce que fait la CI (`scan-ref: '.'`).

Mesuré depuis la racine : **136 → 125**, soit exactement les 11 attendues (1 `KSV-0041`
+ 1 `KSV-0108` + 9 overlays). Toujours mesurer avant/après une exception.

## Vérifications

- [x] `trivy config` : tp06 **43 → 0**, dépôt **168 → 125**
- [x] `kubeconform -strict` sur les 8 manifests modifiés
- [x] `http-echo` et `nginx` testés en conteneur non-root + racine lecture seule
- [x] `kustomize build` vérifié sur les 3 overlays
- [x] Effet de l'exception mesuré avant/après, depuis la racine
- [ ] **Non appliqué sur un cluster** — inchangé depuis la PR #137

## Reste à faire

**125 alertes** : tp04 31, tp09 25, tp08 21, tp05 17, tp03 14, tp07 11, tp01 4, tp10 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
