### PR TITLE
fix: bascule aws-cli et wordpress durcie sur des tags activement maintenus

### DIFF
--- a/docker/hardened/build.sh
+++ b/docker/hardened/build.sh
@@ -21,7 +21,7 @@ IMAGES=(
   "netshoot|telemachlearning/netshoot:v0.16|nicolaka/netshoot:v0.16"
   "curl|telemachlearning/curl:8.21.0|curlimages/curl:8.21.0"
   "httpd|telemachlearning/httpd:2.4-alpine|httpd:2.4-alpine"
-  "wordpress|telemachlearning/wordpress:6.8-php8.3-apache|wordpress:6.8-php8.3-apache"
+  "wordpress|telemachlearning/wordpress:7.0-php8.5-apache|wordpress:7.0-php8.5-apache"
   "hpa-example|telemachlearning/hpa-example:1.0.0|—"
 )
 

--- a/docker/hardened/wordpress/Dockerfile
+++ b/docker/hardened/wordpress/Dockerfile
@@ -1,4 +1,4 @@
-# Image durcie : wordpress:6.8-php8.3-apache
+# Image durcie : wordpress:7.0-php8.5-apache
 # Deux modifications, et rien d'autre :
 #   1. mise à jour des paquets OS de la distribution ;
 #   2. un utilisateur final NON-ROOT (DS-0002).
@@ -11,7 +11,11 @@
 # 33 = www-data, exactement le `runAsUser` qu'impose déjà
 # tp02/exercice10/wordpress-app.yaml : l'image et le manifest disent enfin la même
 # chose. Vérifié : Apache démarre et sert du HTTP (302 vers l'installeur).
-FROM wordpress:6.8-php8.3-apache
+#
+# 6.8-php8.3-apache n'est plus reconstruite depuis le 2025-12-02 (CVE OS non
+# corrigées en amont) ; 7.0-php8.5-apache reste activement reconstruite —
+# même bascule que docker-formation (cf. son post-mortem du 17/07).
+FROM wordpress:7.0-php8.5-apache
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*

--- a/tp02/exercice10/wordpress-app.yaml
+++ b/tp02/exercice10/wordpress-app.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: wordpress
-        image: telemachlearning/wordpress:6.8-php8.3-apache
+        image: telemachlearning/wordpress:7.0-php8.5-apache
         env:
         - name: WORDPRESS_DB_HOST
           value: mysql-service

--- a/tp03/14-network-storage-examples-secure.yaml
+++ b/tp03/14-network-storage-examples-secure.yaml
@@ -584,7 +584,7 @@ spec:
               type: RuntimeDefault
           containers:
           - name: backup
-            image: amazon/aws-cli:2.36.8
+            image: amazon/aws-cli:2.36.21
             command:
             - /bin/sh
             - -c


### PR DESCRIPTION
## Résumé

Corrige l'issue #142 (scan hebdomadaire bloqué sur des CVE OS corrigeables, ouverte par Mirador — abstention honnête mais sans correctif, cf. discussion mirador#25/#27).

Vérifié sur Docker Hub :
- `amazon/aws-cli:2.36.8` → `2.36.21` (dernière version, reconstruite hier)
- `wordpress:6.8-php8.3-apache` n'est plus reconstruite depuis le 2025-12-02 (8 mois) → `wordpress:7.0-php8.5-apache` reste activement reconstruite — même bascule déjà faite sur docker-formation.

## Changement

- `tp03/14-network-storage-examples-secure.yaml` : image aws-cli bumpée.
- `docker/hardened/wordpress/Dockerfile` : `FROM` bumpé (USER 33/www-data inchangé, toujours valide).
- `docker/hardened/build.sh` : tag publié `telemachlearning/wordpress` mis à jour (non dérivé dynamiquement).
- `tp02/exercice10/wordpress-app.yaml` : image durcie bascule vers le nouveau tag.

## Avant de merger

`telemachlearning/wordpress:7.0-php8.5-apache` doit être (re)publiée sur Docker Hub via `rebuild-hardened-images.yml` (workflow_dispatch, `push=true`) — je le déclenche sur cette branche pour valider avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)